### PR TITLE
Update Mephistroth.lua module and add support for users not using superwow.

### DIFF
--- a/Raids/KarazhanUpper/Mephistroth.lua
+++ b/Raids/KarazhanUpper/Mephistroth.lua
@@ -2,317 +2,669 @@ local module, L = BigWigs:ModuleDeclaration("Mephistroth", "Karazhan")
 
 module.revision = 30002
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "shacklescast", "shacklesdebuff", "shackleshatter", "shardscd", "shardschannel", "markdoom", "bosskill" }
+module.toggleoptions = { "shacklescast", "shacklesdebuff", "shackleshatter", "shards", "doomofoutland", "doommark", "sleepparalysis", "sleepparalysismark", "terror", "rainofoutland", -1, "bosskill", "debug_superwow" }
 module.zonename = {
-	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
-	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
-	"Outland",
-	"???"
+    AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
+    AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
+    "Outland",
+    "???"
 }
 
--- module defaults
+-- Module defaults
 module.defaultDB = {
-	shacklescast = true,
-	shacklesdebuff = true,
-	shackleshatter = false,
-	shardscd = true,
-	shardschannel = true,
-	markdoom = true,
+    shacklescast = true,
+    shacklesdebuff = true,
+    shackleshatter = false,
+    shards = true,
+    doomofoutland = true,
+    doommark = true,
+    sleepparalysis = true,
+    sleepparalysismark = true,
+    terror = true,
+    rainofoutland = true,
+    bosskill = true,
+    debug_superwow = false,
 }
 
 L:RegisterTranslations("enUS", function()
-	return {
-		-- options
-		cmd = "Mephistroth",
+    return {
+        cmd = "Mephistroth",
 
-		shacklescast_cmd = "shacklescast",
-		shacklescast_name = "Shackles Cast Alert",
-		shacklescast_desc = "Warn when Mephistroth begins casting Shackles of the Legion.",
+        -- Options
+        shacklescast_cmd = "shacklescast",
+        shacklescast_name = "Shackles Cast Alert",
+        shacklescast_desc = "Warn when Mephistroth begins casting Shackles of the Legion.",
 
-		shacklesdebuff_cmd = "shacklesdebuff",
-		shacklesdebuff_name = "Shackles Debuff Alert",
-		shacklesdebuff_desc = "Warn and timer when Shackles of the Legion lands.",
+        shacklesdebuff_cmd = "shacklesdebuff",
+        shacklesdebuff_name = "Shackles Debuff Alert",
+        shacklesdebuff_desc = "Warn and timer when Shackles of the Legion lands.",
 
-		shackleshatter_cmd = "shackleshatter",
-		shackleshatter_name = "Shackle Shatter Tattle",
-		shackleshatter_desc = "Tell who failed standing still.",
+        shackleshatter_cmd = "shackleshatter",
+        shackleshatter_name = "Shackle Shatter Tattle",
+        shackleshatter_desc = "Tell who failed standing still.",
 
-		shardscd_cmd = "shardscd",
-		shardscd_name = "Shards of Hellfury Countdown",
-		shardscd_desc = "Show countdown to next Shards of Hellfury.",
+        shards_cmd = "shards",
+        shards_name = "Shards of Hellfury Alert",
+        shards_desc = "Show Shards of Hellfury cast, cooldown, channel timers, and shard kill counter.",
 
-		shardschannel_cmd = "shardschannel",
-		shardschannel_name = "Shards of Hellfury Channel Time",
-		shardschannel_desc = "Show time left before Channel enrage.",
+        doomofoutland_cmd = "doomofoutland",
+        doomofoutland_name = "Doom of Outland Alert",
+        doomofoutland_desc = "Warn for Doom of Outland decurse.",
 
-		markdoom_cmd = "markdoom",
-		markdoom_name = "Mark Doom Target",
-		markdoom_desc = "Mark a Doomed player with Triangle.",
+        doommark_cmd = "doommark",
+        doommark_name = "Mark Doom Target",
+        doommark_desc = "Mark Doomed players with Skull.",
 
-		-- triggers
-		trigger_engage = "I foresaw your arrival", -- CHAT_MSG_MONSTER_YELL
-		trigger_shacklesDebuffYou = "You are afflicted by Shackles of the Legion",
-		trigger_shacklesDebuffOther = "(.+) is afflicted by Shackles of the Legion",
-		trigger_doomDebuff = "(.+) ...? afflicted by Doom of Outland",
-		trigger_doomDebuffFade = "Doom of Outland fades from (.+)%.",
+        sleepparalysis_cmd = "sleepparalysis",
+        sleepparalysis_name = "Sleep Paralysis Alert",
+        sleepparalysis_desc = "Warn for Sleep Paralysis dispel.",
 
-		trigger_shacklesFade = "Shackles of the Legion fades from (.+)%.",
+        sleepparalysismark_cmd = "sleepparalysismark",
+        sleepparalysismark_name = "Mark Sleep Paralysis Target",
+        sleepparalysismark_desc = "Mark a Sleep Paralysis player with Moon.",
 
-		trigger_shackleShatterYou = "Your Shackle Shatter .-its",
-		trigger_shackleShatterOther = "(.+)'s Shackle Shatter .-its",
+        terror_cmd = "terror",
+        terror_name = "Nathrezim Terror Alert",
+        terror_desc = "Warn when Mephistroth casts Nathrezim Terror.",
 
-		-- messages & bars
-		msg_shacklesCast = "Shackles of the Legion incoming! >>DO NOT MOVE<<",
-		bar_shacklesCast = "Casting Shackles",
-		msg_shacklesCastAlert = "Shackles Casting >>STOP MOVING<<",
+        rainofoutland_cmd = "rainofoutland",
+        rainofoutland_name = "Rain of Outland Alert",
+        rainofoutland_desc = "Warn for Rain of Outland.",
 
-		bar_shacklesDebuff = "Shackles of the Legion",
-		msg_shacklesDebuffYou = "You are shackled! >>DO NOT MOVE<<",
-		msg_shacklesDebuffOther = "%s is shackled!",
+        debug_superwow_cmd = "debug_superwow",
+        debug_superwow_name = "Enable Superwow Mode",
+        debug_superwow_desc = "Use superwow API to handle shackle cast, shard cast, shard channel, etc.",
 
-		msg_shackleShatter = " didn't keep still.",
+        -- Triggers
+        trigger_engage = "I foresaw your arrival", -- CHAT_MSG_MONSTER_YELL
 
-		bar_shardsChannel = "Shard Enrage",
-		bar_shardsCD      = "Next Shards Cast",
-		msg_shardsCast    = "Hellfire Shards casting, go kill shards!",
-	}
+        trigger_shackleCast = "Mephistroth begins to cast Shackles of the Legion", -- CHAT_MSG_RAID_BOSS_EMOTE
+        trigger_shacklesDebuffYou = "You are afflicted by Shackles of the Legion", -- CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+        trigger_shacklesDebuffOther = "(.+) is afflicted by Shackles of the Legion", -- CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE, CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+        trigger_shacklesFade = "Shackles of the Legion fades from (.+).", -- CHAT_MSG_SPELL_AURA_GONE_SELF, CHAT_MSG_SPELL_AURA_GONE_PARTY, CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+        -- shackle damage trigger
+        trigger_shackleShatterYou = "Your Shackle Shatter hits", -- CHAT_MSG_SPELL_SELF_DAMAGE
+        trigger_shackleShatterOther = "(.+)'s Shackle Shatter hits", -- CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE, CHAT_MSG_SPELL_PARTY_DAMAGE
+
+        -- TODO: add a dispel warning for the vampiric aura
+        -- Is this necessary? Priests can see the debuff with Decursive. （While Shamans can't.)
+        trigger_vampiricAura = "Mephistroth gains Vampiric Aura", -- CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS (Or maybe other events. Not tested yet.)
+
+        trigger_sleepParalysisYou = "You are afflicted by Sleep Paralysis", -- CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+        trigger_sleepParalysisOther = "(.+) is afflicted by Sleep Paralysis", -- CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE, CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+        trigger_sleepParalysisFade = "Sleep Paralysis fades from (.+).", -- CHAT_MSG_SPELL_AURA_GONE_SELF, CHAT_MSG_SPELL_AURA_GONE_PARTY, CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+        trigger_terror = "Mephistroth begins to cast Nathrezim Terror", -- CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+
+        trigger_shard = "Mephistroth begins to cast Shards of Hellfury", -- CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+        trigger_shardDeath = "Hellfury Shard dies", -- CHAT_MSG_COMBAT_HOSTILE_DEATH
+        trigger_shardEnrage = "Mephistroth gains Unfathomed Hatred", -- Unknown Event Type
+
+        trigger_rainOfOutland = "Mephistroth gains Rain of Outland", -- CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+        trigger_rainOfOutlandEnd = "Rain of Outland fades from Mephistroth", -- CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+        trigger_doomDebuffYou = "You are afflicted by Doom of Outland", -- CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+        trigger_doomDebuffOther = "(.+) is afflicted by Doom of Outland", -- CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE, CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+        trigger_doomDebuffFade = "Doom of Outland fades from (.+).", -- CHAT_MSG_SPELL_AURA_GONE_SELF, CHAT_MSG_SPELL_AURA_GONE_PARTY, CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+        trigger_bossDeath = "Mephistroth dies", -- CHAT_MSG_COMBAT_HOSTILE_DEATH
+
+        -- Messages & Bars
+        msg_shacklesCast = "Shackles of the Legion incoming! >>DO NOT MOVE<<",
+        bar_shacklesCast = "Shackles of the Legion",
+        msg_shacklesCastAlert = "Shackles Casting >>STOP MOVING<<",
+        bar_shacklesCD = "Shackles of the Legion Cooldown",
+
+        bar_shacklesDebuff = "Shackles",
+        msg_shacklesDebuffYou = "You are shackled! >>DO NOT MOVE<<",
+        -- msg_shacklesDebuffOther = "%s is shackled! >>DO NOT MOVE<<",
+
+        msg_shackleShatter = "%s didn't keep still!",
+
+        bar_shardsCast = "Shards of Hellfury",
+        bar_shardsChannel = "Shards Enrage",
+        bar_shardsCD = "Shards of Hellfury Cooldown",
+        bar_shardsCounter = "Shard Kills",
+        msg_shardsCast = "Hellfire Shards casting, go kill shards!",
+        msg_shardsEnrage = "Enraged!",
+
+        bar_doomDebuff = "%s Doom",
+        msg_doomDebuffYou = "You are Doomed! Decurse!",
+        msg_doomDebuffOther = "%s is Doomed! Decurse!",
+
+        bar_sleepParalysis = "%s Sleep Paralysis",
+        msg_sleepParalysisYou = "You are paralyzed! Dispel!",
+        msg_sleepParalysisOther = "%s is paralyzed! Dispel!",
+
+        bar_terror = "Nathrezim Terror",
+        bar_terrorCD = "Nathrezim Terror Cooldown",
+        msg_terror = "Fear incoming!",
+
+        bar_rainOfOutland = "Rain of Outland",
+        msg_rainOfOutland = "Rain of Outland! Go kill adds!",
+        msg_rainOfOutlandEnd = "Rain of Outland ended.",
+    }
 end)
 
 local timer = {
-	shacklesInitialCD = { 68, 96 }, -- 60 to 120 ?
-	shacklesCD = { 40, 70 },
-	shacklesCast = 2.5,
-	shacklesDebuff = 6,
-	shardsCast = 6,
-	shardsCD = 120,
-	shardsCD_bar_delay = 25,
-	shardsChannel = 25,
+    shacklesCD = {40, 100}, -- Estimated cooldown range from WCL
+    shacklesCast = 2.5,
+    shacklesDebuff = 6,
+
+    shardsCast = 6,
+    shardsCD = {90, 180}, -- Estimated cooldown range from WCL
+    shardsChannel = 25,
+
+    vampiricAuraCD = {20, 30},   -- not used atm
+
+    terrorCD = {25, 60}, -- Estimated cooldown range from WCL
+    terrorCast = 2.5,
+
+    doomDuration = 8,
+    rainOfOutland = 25,
 }
 
 local icon = {
-	shackles = "INV_Belt_18",
-	shardsCD = "Spell_Fire_Fire",
-	shardsChannel = "Spell_Fire_SoulBurn",
+    shackles = "inv_belt_18",
+    shards = "spell_fire_soulburn",
+    shardsChannel = "spell_fire_soulburn",
+    shardsCounter = "spell_fire_soulburn",
+    doom = "spell_shadow_antishadow",
+    terror = "spell_shadow_deathcoil",
+    sleepParalysis = "inv_misc_eye_01",
+    rainOfOutland = "spell_shadow_rainoffire",
+}
+
+local color = {
+    shacklesCast = "Red",
+    shacklesDebuff = "Orange",
+    shards = "Orange",
+    shardsChannel = "Red",
+    shardsCounter = "Yellow",
+    doomDebuff = "Black",
+    sleepParalysis = "Blue",
+    terror = "Yellow",
+    rainOfOutland = "Red",
 }
 
 local syncName = {
-	shacklesCast = "MephistrothShacklesCast" .. module.revision,
-	shacklesDebuff = "MephistrothShacklesDebuff" .. module.revision,
-	shackleShatter = "MephistrothShackleShatter" .. module.revision,
-	shardsCD = "MephistrothShardsOfHellfuryCD" .. module.revision,
-	shardsChannel = "MephistrothShardsOfHellfuryChannel" .. module.revision,
-	shardsChannelEnd = "MephistrothShardsOfHellfuryChannelEnd" .. module.revision,
-	markDoom = "MephistrothMarkDoom" .. module.revision,
+    shacklesCast = "MephistrothShacklesCast" .. module.revision,
+    shacklesDebuff = "MephistrothShacklesDebuff" .. module.revision,
+    shackleShatter = "MephistrothShackleShatter" .. module.revision,
+    shacklesFade = "MephistrothShacklesFade" .. module.revision,
+    shards = "MephistrothShardsOfHellfury" .. module.revision,
+    shardsChannel = "MephistrothShardsOfHellfuryChannel" .. module.revision,
+    shardsChannelEnd = "MephistrothShardsOfHellfuryChannelEnd" .. module.revision,
+    shardsDeath = "MephistrothShardsOfHellfuryDeath" .. module.revision,
+    shardsEnrage = "MephistrothShardsEnrage" .. module.revision,
+    doomDebuff = "MephistrothDoomDebuff" .. module.revision,
+    doomDebuffFade = "MephistrothDoomDebuffFade" .. module.revision,
+    terror = "MephistrothTerror" .. module.revision,
+    sleepParalysis = "MephistrothSleepParalysis" .. module.revision,
+    sleepParalysisFade = "MephistrothSleepParalysisFade" .. module.revision,
+    rainOfOutland = "MephistrothRainOfOutland" .. module.revision,
+    rainOfOutlandEnd = "MephistrothRainOfOutlandEnd" .. module.revision,
 }
 
 local fail_shards = 0
-
-module:RegisterYellEngage(L.trigger_engage)
-
---------------------------------------------------------------------------------
---  Module OnEnable
---------------------------------------------------------------------------------
+local shardDeaths = 0
+local shardDeathsSelfCount = 0
+local lastShardsCastTime = 0
+local maxShards = 6
+local bossHealth = 100
+local shacklesThresholdReached = false
+local terrorThresholdReached = false
 
 function module:OnSetup()
-	self.started = nil
+    self.started = nil
+    fail_shards = 0
+    shardDeaths = 0
+    shardDeathsSelfCount = 0
+    lastShardsCastTime = 0
+    bossHealth = 100
+    shacklesThresholdReached = false
+    terrorThresholdReached = false
 end
 
--- should sync enables
 function module:OnEnable()
-	if SUPERWOW_STRING or SetAutoloot then
-		self:RegisterEvent("UNIT_CASTEVENT", "MephistrothCastEvent")
-	end
+    if SUPERWOW_STRING or SetAutoloot then
+        self:RegisterEvent("UNIT_CASTEVENT", "MephistrothCastEvent")
+    end
 
-	-- Debuff landing
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Event")
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Event")
-	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "Event")
+    self:RegisterEvent("CHAT_MSG_MONSTER_YELL", "Event") -- Engage
 
-	-- Debuff fading
-	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "DebuffFade")
-	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "DebuffFade")
-	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "DebuffFade")
+    self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE", "Event") -- Shackles of the Legion without superwow
+    self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Event") -- Nathrezim Terror
+    self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "Event") -- Shards of Hellfury Casting
+    self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Event") -- Vampiric Aura, Rain of Outland
+    self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Event") -- Doom of Outland, Sleep Paralysis
+    self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Event") -- Doom of Outland, Sleep Paralysis
+    self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "Event") -- Doom of Outland, Sleep Paralysis
 
-	self:ThrottleSync(2, syncName.shacklesCast)
-	self:ThrottleSync(2, syncName.shacklesDebuff)
-	self:ThrottleSync(2, syncName.shackleShatter)
-	self:ThrottleSync(2, syncName.shardsCD)
-	self:ThrottleSync(5, syncName.shardsChannel)
-	self:ThrottleSync(5, syncName.shardsChannelEnd)
+    -- Debuff fades. Not fully tested yet. Please test this in your encounters.
+    self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "Event") -- Shackles, Doom, Sleep Paralysis
+    self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "Event")
+    self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "Event")
+
+    self:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE", "Event") -- Shackle Shatter
+    self:RegisterEvent("CHAT_MSG_SPELL_PARTY_DAMAGE", "Event")
+    self:RegisterEvent("CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE", "Event")
+
+    self:RegisterEvent("CHAT_MSG_COMBAT_HOSTILE_DEATH") -- Shards death, Boss death
+
+    self:ThrottleSync(2, syncName.shacklesCast)
+    self:ThrottleSync(2, syncName.shacklesDebuff)
+    self:ThrottleSync(2, syncName.shackleShatter)
+    self:ThrottleSync(2, syncName.shacklesFade)
+    self:ThrottleSync(2, syncName.shards)
+    self:ThrottleSync(5, syncName.shardsChannel)
+    self:ThrottleSync(5, syncName.shardsChannelEnd)
+    self:ThrottleSync(0, syncName.shardsDeath)
+    self:ThrottleSync(2, syncName.shardsEnrage)
+    self:ThrottleSync(2, syncName.doomDebuff)
+    self:ThrottleSync(2, syncName.doomDebuffFade)
+    self:ThrottleSync(2, syncName.terror)
+    self:ThrottleSync(2, syncName.sleepParalysis)
+    self:ThrottleSync(2, syncName.sleepParalysisFade)
+    self:ThrottleSync(5, syncName.rainOfOutland)
+    self:ThrottleSync(5, syncName.rainOfOutlandEnd)
 end
 
 function module:OnEngage()
-	fail_shards = 0
+    fail_shards = 0
+    shardDeaths = 0
+    shardDeathsSelfCount = 0
+    lastShardsCastTime = 0
+    bossHealth = 100
+    shacklesThresholdReached = false
+    terrorThresholdReached = false
+    self:ScheduleRepeatingEvent("CheckBossHP", self.CheckBossHP, 1, self)
+    if not SUPERWOW_STRING then
+        self.db.profile.debug_superwow = false
+    end
 end
 
---------------------------------------------------------------------------------
---  Cast Event
---------------------------------------------------------------------------------
+function module:OnDisengage()
+    if self:IsEventScheduled("CheckBossHP") then
+		self:CancelScheduledEvent("CheckBossHP")
+	end
+    self:RemoveBar(L["bar_shardsCD"])
+    self:RemoveBar(L["bar_shardsChannel"])
+    self:TriggerEvent("BigWigs_StopCounterBar", self, L["bar_shardsCounter"])
+    self:RemoveBar(L["bar_terrorCD"])
+end
+
+function module:CheckBossHP()
+    -- todo: warn phase changes at different HP
+    for i = 1, GetNumRaidMembers() do
+        local targetString = "raid" .. i .. "target"
+        local targetName = UnitName(targetString)
+        if targetName == module.translatedName then
+            local health = UnitHealth(targetString)
+            local maxHealth = UnitHealthMax(targetString)
+            if health > 0 and maxHealth > 0 then
+                local healthPercent = (health / maxHealth) * 100
+                if healthPercent < bossHealth then
+                    bossHealth = healthPercent
+                end
+
+                -- Check Shackles threshold (90% HP). 
+                -- Need to confirm. Maybe the threshold is not 90% but 80% or 85%? But I'm sure that the boss will not cast this above 90%
+                if bossHealth < 90 and not shacklesThresholdReached then
+                    shacklesThresholdReached = true
+                    if self.db.profile.shacklescast then
+                        self:IntervalBar(L["bar_shacklesCD"], timer.shacklesCD[1], timer.shacklesCD[2], icon.shackles, true, color.shacklesCast)
+                    end
+                end
+
+                -- Check Terror threshold (50% HP)
+                -- The boss starts terror cooldown after reaching 50% (The 1st rain of outland phase)
+                if bossHealth < 50 and not terrorThresholdReached then
+                    terrorThresholdReached = true
+                    if self.db.profile.terror then
+                        self:IntervalBar(L["bar_terrorCD"], timer.terrorCD[1], timer.terrorCD[2], icon.terror, true, color.terror)
+                    end
+                end
+            end
+            break
+        end
+    end
+end
+
+function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
+    if string.find(msg, L["trigger_bossDeath"]) then
+        BigWigs:CheckForBossDeath(msg, self)
+    elseif string.find(msg, L["trigger_shardDeath"]) then
+        shardDeathsSelfCount = shardDeathsSelfCount + 1
+        if shardDeathsSelfCount <= maxShards then
+            self:Sync(syncName.shardsDeath .. " " .. tostring(shardDeathsSelfCount))
+            if shardDeathsSelfCount == maxShards then
+                shardDeathsSelfCount = 0
+            end
+        end
+    end
+end
+
+-- superwow mode not tested yet
 function module:MephistrothCastEvent(casterGuid, targetGuid, eventType, spellId, castTime)
-	-- if not self.db.profile.shacklescast then return end
-	-- todo: I believe shackles is a channel but don't know for sure yet
+    if not self.db.profile.debug_superwow then return end
+
 	if spellId == 51916 and (eventType == "START" or eventType == "CHANNEL") then
 		self:Sync(syncName.shacklesCast .. " " .. (castTime / 1000))
 	elseif spellId == 51917 then
-		-- Shackle Shatter
 		self:Sync(syncName.shackleShatter .. " " .. UnitName(casterGuid))
 	elseif spellId == 51942 and eventType == "START" then
 		fail_shards = 0
-		self:Sync(syncName.shardsCD)
+		self:Sync(syncName.shardsCast)
 	elseif spellId == 51947 then
 		if eventType == "CHANNEL" then
 			self:Sync(syncName.shardsChannel .. " " .. (castTime / 1000))
 		elseif eventType == "FAIL" then
 			fail_shards = fail_shards + 1
-			if fail_shards == 6 then
+			if fail_shards == maxShards then
 				fail_shards = 0
 				self:Sync(syncName.shardsChannelEnd)
 			end
 		end
-	elseif spellId == 51948 and eventType == "CAST" then
-		-- todo: shard completed, good spot for an enrage indication
 	end
 end
 
---------------------------------------------------------------------------------
---  Debuff landing
---------------------------------------------------------------------------------
 function module:Event(msg)
-	-- if not self.db.profile.shacklesdebuff then return end
+    -- engage
+    if string.find(msg, L["trigger_engage"]) then
+        self:Engage()
+    end
 
-	if self.db.profile.shacklesdebuff then
-		-- self-detected, trigger a debuff alert
-		if string.find(msg, L.trigger_shacklesDebuffYou) then
-			self:ShacklesDebuff(UnitName("player"))
-			return
-		end
-		local _, _, player = string.find(msg, L.trigger_shacklesDebuffOther)
-		if player then
-			self:Sync(syncName.shacklesDebuff .. " " .. player)
-			return
-		end
-	end
-	if self.db.profile.shackleshatter then
-		if string.find(msg, L.trigger_shackleShatterYou) then
-			self:Sync(syncName.shackleShatter .. " " .. UnitName("player"))
-			return
-		end
-		local _, _, player = string.find(msg, L.trigger_shackleShatterOther)
-		if player then
-			self:Sync(syncName.shackleShatter .. " " .. player)
-			return
-		end
-	end
-	if self.db.profile.shackleshatter then
-		if string.find(msg, L.trigger_shackleShatterYou) then
-			self:Sync(syncName.shackleShatter .. " " .. UnitName("player"))
-			return
-		end
-		local _, _, player = string.find(msg, L.trigger_shackleShatterOther)
-		if player then
-			self:Sync(syncName.shackleShatter .. " " .. player)
-			return
-		end
-	end
-	if self.db.profile.markdoom then
-		local _, _, player = string.find(msg, L.trigger_doomDebuff)
-		if player then
-			player = player == "You" and UnitName("player") or player
-			self:SetRaidTargetForPlayer(player, 4) -- tri
-			return
-		end
-		local _, _, player = string.find(msg, L.trigger_doomDebuffFade)
-		if player then
-			player = player == "you" and UnitName("player") or player
-			self:RestorePreviousRaidTargetForPlayer(player)
-		end
-	end
+    -- event handlers without superwow mode
+    if not self.db.profile.debug_superwow or not SUPERWOW_STRING then
+        -- shackle cast (without superwow)
+        if string.find(msg, L["trigger_shackleCast"]) then
+            self:Sync(syncName.shacklesCast)
+        end
+
+        -- shackle shatter
+        if string.find(msg, L["trigger_shackleShatterYou"]) then
+            self:Sync(syncName.shackleShatter .. " " .. UnitName("player"))
+        elseif string.find(msg, L["trigger_shackleShatterOther"]) then
+            local _, _, player = string.find(msg, L["trigger_shackleShatterOther"])
+            self:Sync(syncName.shackleShatter .. " " .. player)
+        end
+
+        -- shards of hellfury
+        if string.find(msg, L["trigger_shard"]) then
+            shardDeathsSelfCount = 0
+            self:Sync(syncName.shards)
+        end
+    end
+
+    -- shackle debuff
+    if string.find(msg, L["trigger_shacklesDebuffYou"]) then
+        self:Sync(syncName.shacklesDebuff .. " " .. UnitName("player"))
+    elseif string.find(msg, L["trigger_shacklesDebuffOther"]) then
+        local _, _, player = string.find(msg, L["trigger_shacklesDebuffOther"])
+        self:Sync(syncName.shacklesDebuff .. " " .. player)
+    end
+
+    -- shackles fade
+    local _, _, player = string.find(msg, L["trigger_shacklesFade"])
+    if player then
+        player = player == "you" and UnitName("player") or player
+        self:Sync(syncName.shacklesFade .. " " .. player)
+    end
+
+    -- doom of outland
+    if string.find(msg, L["trigger_doomDebuffYou"]) then
+        self:Sync(syncName.doomDebuff .. " " .. UnitName("player"))
+    elseif string.find(msg, L["trigger_doomDebuffOther"]) then
+        local _, _, player = string.find(msg, L["trigger_doomDebuffOther"])
+        self:Sync(syncName.doomDebuff .. " " .. player)
+    end
+
+    -- doom of outland fade
+    _, _, player = string.find(msg, L["trigger_doomDebuffFade"])
+    if player then
+        player = player == "you" and UnitName("player") or player
+        self:Sync(syncName.doomDebuffFade .. " " .. player)
+    end
+
+    -- sleep paralysis
+    if string.find(msg, L["trigger_sleepParalysisYou"]) then
+        self:Sync(syncName.sleepParalysis .. " " .. UnitName("player"))
+    elseif string.find(msg, L["trigger_sleepParalysisOther"]) then
+        local _, _, player = string.find(msg, L["trigger_sleepParalysisOther"])
+        self:Sync(syncName.sleepParalysis .. " " .. player)
+    end
+
+    -- sleep paralysis fade
+    _, _, player = string.find(msg, L["trigger_sleepParalysisFade"])
+    if player then
+        player = player == "you" and UnitName("player") or player
+        self:Sync(syncName.sleepParalysisFade .. " " .. player)
+    end
+
+    -- terror
+    if string.find(msg, L["trigger_terror"]) then
+        self:Sync(syncName.terror)
+    end
+
+    -- rain of outland
+    if string.find(msg, L["trigger_rainOfOutland"]) then
+        self:Sync(syncName.rainOfOutland)
+    elseif string.find(msg, L["trigger_rainOfOutlandEnd"]) then
+        self:Sync(syncName.rainOfOutlandEnd)
+    end
+
+    -- rain of outland ends
+    if string.find(msg, L["trigger_rainOfOutlandEnd"]) then
+        self:Sync(syncName.rainOfOutlandEnd)
+    end
+
+    -- shards enrage
+    if string.find(msg, L["trigger_shardEnrage"]) then
+         shardDeathsSelfCount = 0
+        self:Sync(syncName.shardsEnrage)
+    end
 end
 
---------------------------------------------------------------------------------
---  Debuff fades
---------------------------------------------------------------------------------
-function module:DebuffFade(msg)
-	if not self.db.profile.shacklesdebuff then
-		return
-	end
-	local _, _, player = string.find(msg, L.trigger_shacklesFade)
-	if player == "you" then
-		self:RemoveBar(string.format(L.bar_shacklesDebuff, player))
-		self:RemoveWarningSign(icon.shackles)
-	end
-end
-
---------------------------------------------------------------------------------
---  Sync handler
---------------------------------------------------------------------------------
 function module:BigWigs_RecvSync(sync, rest, nick)
-	if sync == syncName.shacklesCast then
-		local castTime = tonumber(rest)
-		self:ShacklesCast(castTime)
-	elseif sync == syncName.shacklesDebuff and rest then
-		self:ShacklesDebuff(rest)
-	elseif sync == syncName.shackleShatter and rest then
-		self:ShackleShatter(rest)
-	elseif sync == syncName.shardsCD then
-		self:ShardsCD()
-	elseif sync == syncName.shardsChannel and rest then
-		local castTime = tonumber(rest)
-		self:ShardsChannel(castTime)
-	elseif sync == syncName.shardsChannelEnd then
-		self:RemoveBar(L.bar_shardsChannel)
-	end
+    if sync == syncName.shacklesCast then
+        local castTime = tonumber(rest) or timer.shacklesCast
+        self:ShacklesCast(castTime)
+    elseif sync == syncName.shacklesDebuff and rest then
+        self:ShacklesDebuff(rest)
+    elseif sync == syncName.shacklesFade and rest then
+        self:ShacklesFade(rest)
+    elseif sync == syncName.shackleShatter and rest then
+        self:ShackleShatter(rest)
+    elseif sync == syncName.shards then
+        self:ShardsCast()
+    elseif sync == syncName.shardsChannel and rest then  -- for superwow mode only
+        local castTime = tonumber(rest)
+        self:ShardsChannel(castTime)
+    elseif sync == syncName.shardsChannelEnd then  -- for superwow mode only
+        self:ShardsChannelEnd()
+    elseif sync == syncName.shardsDeath and rest then
+        self:ShardsDeathHandler(rest)
+    elseif sync == syncName.shardsEnrage then
+        self:ShardsEnrage()
+    elseif sync == syncName.doomDebuff and rest and self.db.profile.doomofoutland then
+        self:DoomDebuff(rest)
+    elseif sync == syncName.doomDebuffFade and rest and self.db.profile.doomofoutland then
+        self:DoomDebuffFade(rest)
+    elseif sync == syncName.sleepParalysis and rest and self.db.profile.sleepparalysis then
+        self:SleepParalysis(rest)
+    elseif sync == syncName.sleepParalysisFade and rest and self.db.profile.sleepparalysis then
+        self:SleepParalysisFade(rest)
+    elseif sync == syncName.terror and self.db.profile.terror then
+        self:Terror()
+    elseif sync == syncName.rainOfOutland and self.db.profile.rainofoutland then
+        self:RainOfOutland()
+    elseif sync == syncName.rainOfOutlandEnd and self.db.profile.rainofoutland then
+        self:RainOfOutlandEnd()
+    end
 end
 
---------------------------------------------------------------------------------
---  Alerts & Bars
---------------------------------------------------------------------------------
 function module:ShacklesCast(castTime)
-	if not self.db.profile.shacklescast then
-		return
-	end
-	local dur = castTime or timer.shacklesCast
-	self:Sound("Beware")
-	self:WarningSign(icon.shackles, dur, true, L.msg_shacklesCastAlert)
-	self:Bar(L.bar_shacklesCast, dur, icon.shackles, true, "Red")
+    if not self.db.profile.shacklescast then return end
+    shacklesThresholdReached = true
+    local dur = castTime or timer.shacklesCast
+    self:Sound("Beware")
+    self:WarningSign(icon.shackles, dur, true, L["msg_shacklesCastAlert"])
+    self:RemoveBar(L["bar_shacklesCD"])
+    self:Bar(L["bar_shacklesCast"], dur, icon.shackles, true, color.shacklesCast)
+    self:DelayedIntervalBar(dur, L["bar_shacklesCD"], timer.shacklesCD[1]-timer.shacklesCast, timer.shacklesCD[2]-timer.shacklesCast, icon.shackles, true, color.shacklesCast)
 end
 
 function module:ShacklesDebuff(player)
-	if not self.db.profile.shacklesdebuff then
-		return
-	end
-	-- 0.5 leeway added to encourage people not to move too early
-	if player == UnitName("player") then
-		self:WarningSign(icon.shackles, timer.shacklesDebuff + 0.5, true, L.msg_shacklesDebuffYou)
-		self:Sound("Alarm")
-	end
-	self:Bar(L.bar_shacklesDebuff, timer.shacklesDebuff + 0.5, icon.shackles)
+    if not self.db.profile.shacklesdebuff then return end
+    if player == UnitName("player") then
+        self:Message(L["msg_shacklesDebuffYou"], "Personal", false, nil, false)
+        self:WarningSign(icon.shackles, timer.shacklesDebuff + 0.3, true, L["msg_shacklesDebuffYou"])
+        self:Sound("Alarm")
+        self:Bar(string.format(L["bar_shacklesDebuff"]), timer.shacklesDebuff + 0.3, icon.shackles, true, color.shacklesDebuff)
+    end
+end
+
+function module:ShacklesFade(player)
+    if not self.db.profile.shacklesdebuff then return end
+    if player == UnitName("player") then
+        self:RemoveBar(L["bar_shacklesDebuff"])
+        self:RemoveWarningSign(icon.shackles)
+    end
 end
 
 function module:ShackleShatter(player)
-	if not self.db.profile.shackleshatter then
-		return
-	end
-	player = player == UnitName("player") and "You" or player
-	self:Message(player .. L.msg_shackleShatter, "Important", false, nil, false)
+    if not self.db.profile.shackleshatter then return end
+    player = player == UnitName("player") and "You" or player
+    self:Message(string.format(L["msg_shackleShatter"], player), "Important", false, nil, false)
+    self:Sound("Info")
 end
 
-function module:ShardsCD()
-	if not self.db.profile.shardscd then
-		return
-	end
-	self:RemoveBar(L.bar_shardsCD)
-	self:Message(L.msg_shardsCast, "Important", false, nil, false)
-	self:DelayedBar(timer.shardsCD_bar_delay, L.bar_shardsCD, timer.shardsCD-timer.shardsCD_bar_delay, icon.shardsCD, true, "Orange")
+function module:ShardsCast()
+    if not self.db.profile.shards then return end
+    lastShardsCastTime = GetTime()
+    shardDeaths = 0
+    self:RemoveBar(L["bar_shardsCD"])
+    self:Bar(L["bar_shardsCast"], timer.shardsCast, icon.shards, true, color.shards)
+    self:Message(L["msg_shardsCast"], "Important", false, nil, false)
+    self:Sound("Alert")
+
+
+    if not self.db.profile.debug_superwow or not SUPERWOW_STRING then
+        self:DelayedBar(timer.shardsCast, L["bar_shardsChannel"], timer.shardsChannel, icon.shardsChannel, true, color.shardsChannel)
+        -- start shard kill counter bar
+        self:TriggerEvent("BigWigs_StartCounterBar", self, L["bar_shardsCounter"], maxShards, "Interface\\Icons\\"..icon.shards, true, color.shards)
+        self:TriggerEvent("BigWigs_SetCounterBar", self, L["bar_shardsCounter"], shardDeaths)
+    else  -- Add a shards CD timer for superwow mode
+        self:DelayedIntervalBar(timer.shardsCast, L["bar_shardsCD"], timer.shardsCD[1]-timer.timer.shardsCast, timer.shardsCD[2]-timer.timer.shardsCast, icon.shards, true, color.shards)
+    end
 end
 
-function module:ShardsChannel(castTime)
-	if not self.db.profile.shardschannel then
-		return
-	end
-	local dur = castTime or timer.shardsChannel
-	self:Sound("Alarm")
-	self:Bar(L.bar_shardsChannel, dur, icon.shardsChannel, true, "Red")
+function module:ShardsChannel(castTime)   -- superwow mode only
+    if not self.db.profile.shards then return end
+    local dur = castTime or timer.shardsChannel
+    self:Sound("Alarm")
+    self:Bar(L["bar_shardsChannel"], dur, icon.shardsChannel, true, color.shardsChannel)
+end
+
+function module:ShardsChannelEnd()  -- superwow mode only
+    if not self.db.profile.shards then return end
+    self:RemoveBar(L["bar_shardsChannel"])
+end
+
+function module:ShardsDeathHandler(count)
+    -- not enabled for superwow_mode
+    if not self.db.profile.shards or (self.db.profile.debug_superwow and SUPERWOW_STRING) then return end
+    local newCount = tonumber(count)
+    if newCount and newCount > shardDeaths and newCount <= maxShards then
+        shardDeaths = newCount
+        -- Update counter bar
+        self:TriggerEvent("BigWigs_SetCounterBar", self, L["bar_shardsCounter"], shardDeaths)
+        if shardDeaths >= maxShards then
+            self:RemoveBar(L["bar_shardsChannel"])
+            self:TriggerEvent("BigWigs_StopCounterBar", self, L["bar_shardsCounter"])
+
+            -- calculate the cooldown for the next shards cast
+            local elapsed = GetTime() - lastShardsCastTime
+            local minCD = timer.shardsCD[1] - elapsed
+            local maxCD = timer.shardsCD[2] - elapsed
+            if minCD < 0 then minCD = 0 end
+            if maxCD < 0 then maxCD = 0 end
+            self:IntervalBar(L["bar_shardsCD"], minCD, maxCD, icon.shards, true, color.shards)
+        end
+    end
+end
+
+function module:ShardsEnrage()
+    if not self.db.profile.shards then return end
+    shardDeaths = 0
+    self:RemoveBar(L["bar_shardsChannel"])
+    self:TriggerEvent("BigWigs_StopCounterBar", self, L["bar_shardsCounter"])
+    self:Message(L["msg_shardsEnrage"], "Important", false, nil, false)
+end
+
+function module:DoomDebuff(player)
+    if not self.db.profile.doomofoutland then return end
+    if player == UnitName("player") then
+        self:Message(L["msg_doomDebuffYou"], "Personal", false, nil, false)
+    else
+        self:Message(string.format(L["msg_doomDebuffOther"], player), "Urgent", false, nil, false)
+    end
+    self:Bar(string.format(L["bar_doomDebuff"], player), timer.doomDuration, icon.doom, true, color.doomDebuff)
+    if self.db.profile.doommark then
+        self:SetRaidTargetForPlayer(player, 8)
+    end
+end
+
+function module:DoomDebuffFade(player)
+    if not self.db.profile.doomofoutland then return end
+    self:RemoveBar(string.format(L["bar_doomDebuff"], player))
+    if self.db.profile.doommark then
+        self:RestorePreviousRaidTargetForPlayer(player)
+    end
+end
+
+function module:SleepParalysis(player)
+    if not self.db.profile.sleepparalysis then return end
+    if player == UnitName("player") then
+        self:Message(L["msg_sleepParalysisYou"], "Personal", false, nil, false)
+    else
+        self:Message(string.format(L["msg_sleepParalysisOther"], player), "Urgent", false, nil, false)
+    end
+    if self.db.profile.sleepparalysismark then
+        self:SetRaidTargetForPlayer(player, 5)
+    end
+end
+
+function module:SleepParalysisFade(player)
+    if not self.db.profile.sleepparalysis then return end
+    if self.db.profile.sleepparalysismark then
+        self:RestorePreviousRaidTargetForPlayer(player)
+    end
+end
+
+function module:Terror()
+    terrorThresholdReached = true
+    if not self.db.profile.terror then return end
+    self:RemoveBar("bar_terrorCD")
+    self:Message(L["msg_terror"], "Urgent", false, nil, false)
+    self:Sound("Alarm")
+    self:WarningSign(icon.terror, timer.terrorCast)
+    self:Bar(L["bar_terror"], timer.terrorCast, icon.terror, true, color.terror)
+    self:DelayedIntervalBar(timer.terrorCast, L["bar_terrorCD"], timer.terrorCD[1]-timer.terrorCast, timer.terrorCD[2]-timer.terrorCast, icon.terror, true, color.terror)
+end
+
+function module:RainOfOutland()
+    if not self.db.profile.rainofoutland then return end
+    self:Message(L["msg_rainOfOutland"], "Important", false, nil, false)
+    self:Bar(L["bar_rainOfOutland"], timer.rainOfOutland, icon.rainOfOutland, true, color.rainOfOutland) -- Assumed duration
+end
+
+function module:RainOfOutlandEnd()
+    if not self.db.profile.rainofoutland then return end
+    self:Message(L["msg_rainOfOutlandEnd"], "Positive", false, nil, false)
+    self:RemoveBar(L["bar_rainOfOutland"])
 end
 
 --------------------------------------------------------------------------------
@@ -408,3 +760,56 @@ function module:Test()
 	BigWigs:Print("Mephistroth Shackles self‑test running...")
 end
 -- /run BigWigs:GetModule("Mephistroth"):Test()
+
+-- Other test commands
+if false then
+--[[
+/run BigWigs:EnableModule("Mephistroth") 
+
+/script BigWigs:TriggerEvent("CHAT_MSG_MONSTER_YELL", "I foresaw your arrival. I don't remember the rest XD.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_RAID_BOSS_EMOTE", "Mephistroth begins to cast Shackles of the Legion.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "You are afflicted by Shackles of the Legion.")
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Tbcisbest is afflicted by Shackles of the Legion.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "Shackles of the Legion fades from you.")
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "Shackles of the Legion fades from Illidan.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_SELF_DAMAGE", "Your Shackle Shatter hits Illidan for 7000 damage.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE", "Tbcisbest's Shackle Shatter hits You for 2000 damage.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Mephistroth gains Vampiric Aura (1).")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "You are afflicted by Sleep Paralysis.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Tbcisbest is afflicted by Sleep Paralysis.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "Sleep Paralysis fades from you.") 
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "Sleep Paralysis fades from Tbcisbest.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Mephistroth begins to cast Nathrezim Terror.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "Mephistroth begins to cast Shards of Hellfury.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_COMBAT_HOSTILE_DEATH", "Hellfury Shard dies.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Mephistroth gains Unfathomed Hatred (1).")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Mephistroth gains Rain of Outland (1).")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "Rain of Outland fades from Mephistroth.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "You are afflicted by Doom of Outland.")
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Tbcisbest is afflicted by Doom of Outland.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "Doom of Outland fades from you.") 
+/script BigWigs:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "Doom of Outland fades from Tbcisbest.")
+
+/script BigWigs:TriggerEvent("CHAT_MSG_COMBAT_HOSTILE_DEATH", "Mephistroth dies.")
+
+/script BigWigs:DisableModule("Mephistroth")
+
+--]]
+end


### PR DESCRIPTION
I have tested the updated Mephistroth.lua locally, but it's not fully tested in real encounters. There might be bugs (due to incorrect use of wow APIs). Also, an option is added to enable/disable superwow mode. It's a mode using superwow API to handle shackles and shards (disabled by default and this part remains unchanged).