### PR TITLE
Add zhCN localizations for raid modules and core UI

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -211,6 +211,77 @@ L:RegisterTranslations("deDE", function()
 	}
 end)
 
+L:RegisterTranslations("zhCN", function()
+	return {
+		["%s mod enabled"] = "%s 模块已启用",
+		["Target monitoring enabled"] = "目标监视已启用",
+		["Target monitoring disabled"] = "目标监视已禁用",
+		["%s engaged!"] = "%s 开战！",
+		["%s has been defeated"] = "%s 已被击败",
+		["%s have been defeated"] = "%s 已被击败",
+
+		["boss"] = "boss",
+		["Bosses"] = "Boss 模块",
+		["Options for boss modules."] = "Boss 模块设置。",
+		["Options for bosses in %s."] = "%s 的 Boss 模块设置。",
+		["Options for %s (r%s)."] = "%s (r%s) 的设置。",
+		["plugin"] = "插件",
+		["Plugins"] = "插件模块",
+		["Options for plugins."] = "插件模块设置。",
+		["extra"] = "额外",
+		["Extras"] = "额外功能",
+		["Options for extras."] = "额外功能设置。",
+		["toggle"] = "切换",
+		["Active"] = "启用",
+		["Activate or deactivate this module."] = "启用或停用此模块。",
+		["reboot"] = "重启",
+		["rebootall"] = "重启全部",
+		["Reboot"] = "重启",
+		["Reboot All"] = "重启全部",
+		["Reboot this module."] = "重启此模块。",
+		["debug"] = "调试",
+		["Debugging"] = "调试",
+		["Show debug messages."] = "显示调试信息。",
+		["Forces the module to reset for everyone in the raid.\n\n(Requires assistant or higher)"] = "强制重置团队中所有人的模块。\n\n(需要助理或更高权限)",
+		["%s has requested forced reboot for the %s module."] = "%s 请求强制重启 %s 模块。",
+		bosskill_cmd = "kill",
+		bosskill_name = "Boss 死亡",
+		bosskill_desc = "当 Boss 被击败时通告",
+
+		["Other"] = "其他",
+		["Load"] = "加载",
+		["Load All"] = "加载全部",
+		["Load all %s modules."] = "加载所有 %s 模块。",
+
+		["Zul'Gurub"] = "ZG",
+		["Molten Core"] = "MC",
+		["Blackwing Lair"] = "BWL",
+		["Ahn'Qiraj"] = "AQ40",
+		["Ruins of Ahn'Qiraj"] = "AQ20",
+		["Onyxia's Lair"] = "Onyxia",
+		["Naxxramas"] = "Naxxramas",
+		["Emerald Sanctum"] = "EmeraldSanctum",
+		["Tower of Karazhan"] = "Karazhan",
+		["Dire Maul"] = "DireMaul",
+		["Blackrock Spire"] = "BlackrockSpire",
+		["The Black Morass"] = "BlackMorass",
+		["Silithus"] = "Silithus",
+		["Outdoor Raid Bosses"] = "Outdoor",
+		["Outdoor Raid Bosses Zone"] = "Outdoor Raid Bosses",
+
+		["Battlegrounds"] = "战场",
+		["Alterac Valley"] = "Alterac Valley",
+		["Arathi Basin"] = "Arathi Basin",
+
+		["Vaelastrasz the Corrupt"] = "堕落的瓦拉斯塔兹",
+		["Lord Victor Nefarius"] = "维克多·奈法里奥斯领主",
+		["Solnius"] = "索尔纽斯",
+		["Lieutenant General Andorov"] = "安多洛夫中将",
+
+		["You have slain %s!"] = "你击杀了 %s！",
+	}
+end)
+
 
 ---------------------------------
 --      Addon Declaration      --
@@ -1546,4 +1617,3 @@ function BigWigs:CancelAuraTexture(texture)
 
 	return false
 end
-

--- a/Options.lua
+++ b/Options.lua
@@ -79,6 +79,29 @@ L:RegisterTranslations("deDE", function()
 	}
 end)
 
+L:RegisterTranslations("zhCN", function()
+	return {
+		["|cff00ff00Module running|r"] = "|cff00ff00模块运行中|r",
+		["|cffeda55fClick|r to reset all running modules. |cffeda55fCtrl+Click|r to force reboot for everyone (Requires assistant or higher). |cffeda55fAlt+Click|r to disable them. |cffeda55fCtrl+Alt+Click|r to disable Big Wigs completely."] = "|cffeda55f点击|r重置所有运行中的模块。|cffeda55fCtrl+点击|r为全团强制重启（需要助理或更高权限）。|cffeda55fAlt+点击|r禁用这些模块。|cffeda55fCtrl+Alt+点击|r完全禁用 Big Wigs。",
+		["|cffeda55fClick|r to enable."] = "|cffeda55f点击|r启用。",
+		["Big Wigs is currently disabled."] = "Big Wigs 当前已禁用。",
+		["Active boss modules"] = "当前启用的 Boss 模块",
+		["hidden"] = "隐藏",
+		["shown"] = "显示",
+		["minimap"] = "minimap",
+		["Minimap"] = "小地图按钮",
+		["Toggle the minimap button."] = "切换小地图按钮显示。",
+		["All running modules have been reset."] = "所有运行中的模块已重置。",
+		["All running modules have been rebooted for all raid members."] = "已为所有团队成员重启所有运行中的模块。",
+		["All running modules have been disabled."] = "所有运行中的模块已禁用。",
+		["%s reset."] = "%s 已重置。",
+		["%s disabled."] = "%s 已禁用。",
+		["%s icon is now %s."] = "%s 图标现在为 %s。",
+		["Show it again with /bw plugin minimap."] = "使用 `/bw plugin minimap` 再次显示。",
+		["You need to be an assistant or raid leader to use this function."] = "你需要是助理或团长才能使用此功能。",
+	}
+end)
+
 ----------------------------------
 --      Module Declaration      --
 ----------------------------------
@@ -232,4 +255,3 @@ function BigWigsOptions:OnClick()
 
 	self:UpdateTooltip()
 end
-

--- a/Plugins/Messages.lua
+++ b/Plugins/Messages.lua
@@ -170,6 +170,59 @@ L:RegisterTranslations("deDE", function()
 	}
 end)
 
+L:RegisterTranslations("zhCN", function()
+	return {
+		["Messages"] = "信息提示",
+
+		["msg"] = "消息",
+		["anchor"] = "框体锚点",
+		["reset"] = "重置",
+		["rw"] = "团队警报",
+		["color"] = "颜色",
+		["scale"] = "大小",
+
+		["Options for the message frame."] = "消息显示模式及相关设置。",
+		["Anchor"] = "信息框锚点",
+		["Show the message anchor frame."] = "显示信息框锚点。",
+		["Use RaidWarning"] = "使用团队通告",
+		["Toggle sending messages to the RaidWarnings frame."] = "切换是否发送到团队通告框。",
+		["Use colors"] = "使用彩色消息",
+		["Toggles white only messages ignoring coloring."] = "切换为仅显示白色消息。",
+		["Message frame scale"] = "信息框缩放",
+
+		["Reset position"] = "重置位置",
+		["Reset the anchor position, moving it to the default location"] = "将锚点重置到默认位置。",
+
+		["Message frame"] = "信息框",
+		["Show anchor"] = "显示锚点",
+		["Send messages to RaidWarning frame"] = "发送到团队通告框",
+		["Set the message frame scale."] = "设置消息框缩放。",
+		["Colorize messages"] = "彩色消息",
+		["Scale"] = "缩放",
+
+		["|cffff0000Co|cffff00fflo|cff00ff00r|r"] = "|cffff0000颜|cffff00ff色|cff00ff00色|r",
+		["White"] = "白色",
+		["BigWigs frame"] = "BigWigs 窗口",
+		["RaidWarning frame"] = "团队通告框",
+		["Scale is set to %s"] = "缩放已设置为 %s",
+		["Messages are now sent to the %2$s"] = "消息现在发送到 %2$s",
+		["Messages are currently sent to the %2$s"] = "消息当前发送到 %2$s",
+
+		["display"] = "显示",
+		["Display"] = "显示",
+		["Set where messages are displayed."] = "设置消息显示位置。",
+		["Display is now set to %2$s"] = "显示位置已设置为 %2$s",
+		["Display is currently set to %2$s"] = "当前显示位置为 %2$s",
+
+		["Mik's Scrolling Battle Text"] = "MSBT",
+		["Scrolling Combat Text"] = "SCT",
+		["Floating Combat Text"] = "浮动战斗信息",
+
+		["Test"] = "测试",
+		["Close"] = "关闭",
+	}
+end)
+
 ----------------------------------
 --      Module Declaration      --
 ----------------------------------

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -137,6 +137,20 @@ L:RegisterTranslations("deDE", function()
 	}
 end)
 
+L:RegisterTranslations("zhCN", function()
+	return {
+		["Sounds"] = "声音",
+		["sounds"] = "声音",
+		["Options for sounds."] = "声音相关设置。",
+		["toggle"] = "切换",
+		["Use sounds"] = "启用声音",
+		["Toggle sounds on or off."] = "打开或关闭声音提醒。",
+		["default"] = "默认",
+		["Default only"] = "仅默认音效",
+		["Use only the default sound."] = "仅使用默认报警音。",
+	}
+end)
+
 ----------------------------------
 --      Module Declaration      --
 ----------------------------------

--- a/Raids/AQ20/Ayamiss.lua
+++ b/Raids/AQ20/Ayamiss.lua
@@ -31,6 +31,34 @@ L:RegisterTranslations("enUS", function() return {
 	larvaname = "Hive'Zara Larva",	
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Ayamiss",
+
+	sacrifice_cmd = "sacrifice",
+	sacrifice_name = "祭品警报",
+	sacrifice_desc = "被作为祭品时进行警告",
+	
+	bigicon_cmd = "bigicons",
+	bigicon_name = "击杀幼虫时显示图标警报",
+	bigicon_desc = "当幼虫产生时显示大图标警告",
+	
+	
+	sacrificeother_trigger = "(.*) is afflicted by Paralyze.",
+	sacrificeyou_trigger = "(.*) are afflicted by Paralyze.",
+	sacrificeend_trigger = "Paralyze fades from",
+	
+	larva_bar = "幼虫 >点我!<",
+	nextlarva_bar = "幼虫/牺牲冷却",
+	
+	msg_sacrifice = " 牺牲，击杀幼虫!",
+	
+	p2_msg = "第二阶段",
+
+	larvaname = "札拉幼虫",	
+} end )
 local timer = {
 	sacrifice = 10,
 	larvacd = 14,

--- a/Raids/AQ20/Buru.lua
+++ b/Raids/AQ20/Buru.lua
@@ -70,6 +70,38 @@ L:RegisterTranslations("esES", function() return {
 	you = "Tu",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Buru",
+
+	watch_cmd = "watch",
+	watch_name = "凝视警报",
+	watch_desc = "警告谁正在被凝视",
+	
+	dismember_cmd = "dismember",
+	dismember_name = "肢解警报",
+	dismember_desc = "肢解出现时进行警告",
+	
+	phase_cmd = "phase",
+	phase_name = "阶段警报",
+	phase_desc = "阶段转换时进行警告",
+	
+	trigger_watch = "sets eyes on (.+)!",--CHAT_MSG_MONSTER_EMOTE
+	msg_watch = " 被布鲁盯上了！",
+	trigger_watchEnd = "Buru Egg's Explosion hits Buru the Gorger for",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	msg_watchEnd = "布鲁不再跟踪你了。",
+	
+	trigger_dismemberYouOne = "You are afflicted by Dismember.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+		trigger_dismemberYouMore = "You are afflicted by Dismember %((.+)%).",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_dismemberOtherOne = "(.+) is afflicted by Dismember.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+		trigger_dismemberOtherMore = "(.+) is afflicted by Dismember %((.+)%).",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	bar_dismember = " 斩杀",
+	
+	msg_phase2 = "第二阶段，DPS全力输出布鲁!",
+	you = "你",
+} end )
 local timer = {
 	dismember = 10,
 }

--- a/Raids/AQ20/FleshHunter.lua
+++ b/Raids/AQ20/FleshHunter.lua
@@ -16,6 +16,15 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "FleshHunter",
+	consumeother_trigger = "(.*)受到了吞噬效果的影响。",
+	consume_bar = " 被吞噬!",
+	clickme = " >点击我！<",
+} end )
 local timer = {
 	consume = 15,
 }

--- a/Raids/AQ20/GeneralRajaxx.lua
+++ b/Raids/AQ20/GeneralRajaxx.lua
@@ -96,6 +96,100 @@ L:RegisterTranslations("enUS", function() return {
 	bar_thundercrash = "Thundercrash CD",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Rajaxx",
+
+	wave_cmd = "wave",
+	wave_name = "来袭警报",
+	wave_desc = "当新一批敌人来袭时发出警告",
+	
+	fear_cmd = "fear",--1
+	fear_name = "恐惧警报",
+	fear_desc = "恐惧状态出现时进行警告",
+	
+	attackorder_cmd = "attackorder",--2
+	attackorder_name = "攻击指令警报",
+	attackorder_desc = "攻击指令出现时进行警告",
+	
+	lightningcloud_cmd = "lightningcloud",--3
+	lightningcloud_name = "闪电云警报",
+	lightningcloud_desc = "闪电云出现时进行警告",
+	
+	shockwave_cmd = "shockwave",--4
+	shockwave_name = "震荡波警报",
+	shockwave_desc = "震荡波出现时进行警告",
+	
+	shield_cmd = "shield",--5
+	shield_name = "护盾警报",
+	shield_desc = "护盾出现时进行警告",
+	
+	knockback_cmd = "knockback",--6
+	knockback_name = "击退警报",
+	knockback_desc = "击退出现时进行警告",
+	
+	enlarge_cmd = "enlarge",--7
+	enlarge_name = "巨化术警报",
+	enlarge_desc = "巨化术出现时进行警告",
+	
+	thundercrash_cmd = "thundercrash",--2
+	thundercrash_name = "雷霆冲击警报",
+	thundercrash_desc = "雷霆冲击出现时进行警告",
+	
+	
+	trigger_eventStarted = "拉贾克斯，还记得我说过要杀光其他虫子之后再干掉你么？",--CHAT_MSG_MONSTER_YELL
+	bar_eventStart = "战斗开始",
+	
+	--not using trigger_wave1 -> bc if you body pull, will cause the trigger to happen at wave 2
+	--trigger_wave1 = "Kill first, ask questions later... Incoming!",--CHAT_MSG_MONSTER_YELL
+	msg_wave1 = "第1/8波 -- 4名战士，2名钉刺者，奎兹上尉 -> 恐惧",
+	trigger_fear = "受到了破胆怒吼效果的影响。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	bar_fear = "恐惧冷却",
+	
+	trigger_wave2 = "奎兹上尉死亡了。",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+	msg_wave2 = "第2/8波 -- 3名战士，3名钉刺者，图比德上尉 -> 标记",
+	trigger_attackOrder = "(.*)受到了攻击命令效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_attackOrderYou = "你受到了攻击命令效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	bar_attackOrder = " 被标记",
+	trigger_attackOrderFade = "攻击命令效果从(.*)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_wave3 = "我们复仇的时刻到了！让敌人的内心被黑暗吞噬吧!",--CHAT_MSG_MONSTER_YELL
+	msg_wave3 = "第3/8波 -- 1名战士，5名钉刺者，德雷恩上尉 -> 闪电云",
+	trigger_lightningCloud = "你受到了闪电之云效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	msg_lightningCloud = "闪电云，快躲开！",
+	trigger_lightningCloudFade = "闪电之云效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_wave4 = "我们不用再呆在这座石墙里面了！我们很快就能报仇了！在我们的怒火面前，就连那些龙也会战栗！",--??\n?? CHAT_MSG_MONSTER_YELL
+	msg_wave4 = "第4/8波 -- 2名战士，4名钉刺者，库雷姆上尉 -> 范围伤害",
+	trigger_shockwave = "瑟瑞姆上尉的震荡波",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	bar_shockwave = "震荡波冷却",
+	
+	trigger_wave5 = "让敌人胆战心惊吧！让他们在恐惧中死去！",--CHAT_MSG_MONSTER_YELL
+	msg_wave5 = "第5/8波 -- 2名战士，4名钉刺者，叶吉斯少校 -> 护盾",
+	trigger_shield = "叶吉斯少校获得了拉贾克斯之盾的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_shield = "免疫魔法",
+	
+	trigger_wave6 = "鹿盔将会呜咽着哀求我绕他一命，就像他那懦弱的儿子一样！一千来的屈辱会在今天洗清！",--??\n?? CHAT_MSG_MONSTER_YELL
+	msg_wave6 = "第6/8波 -- 4名战士，2名钉刺者，帕库少校 -> 击退",
+	trigger_slam = "帕库少校的横扫猛击",--
+	bar_slam = "猛击冷却",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	
+	trigger_wave7 = "范达尔！你的死期到了！藏到翡翠梦境里去吧，祈祷我们永远都找不到你！",--??\n?? CHAT_MSG_MONSTER_YELL
+	msg_wave7 = "第7/8波 -- 3名战士，3名钉刺者，泽朗上校 -> 扩大",
+	trigger_enlarge = "泽朗上校获得了放大的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_enlarge = "扩大，驱散！",
+	msg_enlarge = "扩大，驱散！",
+	trigger_enlargeFade = "放大效果从泽朗上校身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+	
+	trigger_wave8 = "无礼的蠢货！我会亲自要了你们的命！",--CHAT_MSG_MONSTER_YELL
+	msg_wave8 = "第8/8波 -- 拉贾克斯将军",
+	trigger_thundercrash = "雷霆碰撞",
+	bar_thundercrash = "雷霆冲击 CD",
+	clickme = " >点击我！<",
+	you = "你",
+} end )
 local timer = {
 	eventStart = 34.72,
 	

--- a/Raids/AQ20/Guardians.lua
+++ b/Raids/AQ20/Guardians.lua
@@ -88,6 +88,87 @@ L:RegisterTranslations("enUS", function()
 		msg_enrage = "Enraged!",
 	}
 end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Guardian",
+
+    reflect_cmd = "reflect",
+    reflect_name = "法术反射警报",
+    reflect_desc = "显示守护者拥有的反射法术的计时条",
+
+    plague_cmd = "plague",
+    plague_name = "瘟疫警报",
+    plague_desc = "瘟疫出现时进行警告",
+
+    icon_cmd = "icon",
+    icon_name = "瘟疫团队标记",
+    icon_desc = "在最后一个被瘟疫感染的人身上放置团队标记（需要助理或更高权限）",
+
+    thunderclap_cmd = "thunderclap",
+    thunderclap_name = "雷霆一击警报",
+    thunderclap_desc = "雷霆一击出现时进行警告",
+
+    shadowstorm_cmd = "shadowstorm",
+    shadowstorm_name = "暗影风暴警报",
+    shadowstorm_desc = "暗影风暴出现时进行警告",
+
+    meteor_cmd = "meteor",
+    meteor_name = "流星警报",
+    meteor_desc = "流星出现时进行警告",
+
+    explode_cmd = "explode",
+    explode_name = "爆炸警报",
+    explode_desc = "爆炸出现时进行警告",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+	
+	
+	trigger_arcaneFireReflect1 = "月火术被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect2 = "灼烧被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect3 = "烈焰震击被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect4 = "火球术被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect5 = "烈焰鞭笞被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect6 = "侦测魔法被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+    bar_fireArcaneReflect = "火焰 & 奥术反射",
+	
+	trigger_shadowFrostReflect1 = "暗言术：痛被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect2 = "腐蚀术被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect3 = "寒冰箭被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect4 = "冰霜震击被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect5 = "阿努比萨斯守卫者受到了侦测魔法效果的影响。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    bar_shadowFrostReflect = "暗影 & 冰霜反射",
+	
+	trigger_selfReflect = "你的(.*)被阿努比萨斯守卫者反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_selfReflect = "法术反射 - 停止自残！",
+	
+	trigger_plagueYou = "你受到了瘟疫效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_plagueOther = "(.+)受到了瘟疫效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_plague = "瘟疫",
+    msg_plague = "瘟疫在 ",
+	
+	trigger_thunderClap = "阿努比萨斯守卫者的雷霆震击", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_thunderClap = "雷霆一击",
+    msg_thunderClap = "雷霆一击 - 远程远离！",
+
+	trigger_shadowStorm = "阿努比萨斯守卫者的暗影风暴", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_shadowStorm = "暗影风暴",
+    msg_shadowStorm = "暗影风暴 - 远程靠近！",
+
+	trigger_meteor = "阿努比萨斯守卫者的流星", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_meteor = "流星",
+    msg_meteor = "流星！",
+	
+	trigger_explode = "阿努比萨斯守卫者获得了爆炸的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_explode = "即将爆炸！",
+    msg_explode = "即将爆炸！快跑！！！",
+
+	trigger_enrage = "阿努比萨斯守卫者获得了狂怒的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "狂暴！加大治疗！",
+} end )
 local timer = {
 	--the timers for tClap, sStorm, meteor vary too much,
 	--will just put 600 so bars tell people what abilities they have

--- a/Raids/AQ20/HiveZaraSoldier.lua
+++ b/Raids/AQ20/HiveZaraSoldier.lua
@@ -30,6 +30,28 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "HiveZaraSoldier",
+
+	retaliationgain_cmd = "retaliationgain",
+	retaliationgain_name = "反击风暴获得警报",
+	retaliationgain_desc = "警告获得反击风暴",
+	
+	retaliationhityou_cmd = "retaliationhityou",
+	retaliationhityou_name = "反击风暴警报",
+	retaliationhityou_desc = "警报反击风暴对你的攻击",
+	
+	trigger_retaliationGain = "佐拉士兵获得了反击风暴的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	msg_retaliationGain = "佐拉士兵获得了反击风暴！",
+	
+	trigger_retaliationHitYou = "佐拉士兵的反击风暴击中你造成",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	msg_retaliationHitYou = "请停止自残！",
+	
+	["You have slain %s!"] = "你已击败%s！",
+} end )
 local timer = {
 }
 local icon = {

--- a/Raids/AQ20/Kurinaxx.lua
+++ b/Raids/AQ20/Kurinaxx.lua
@@ -33,6 +33,37 @@ L:RegisterTranslations("enUS", function() return {
 	msg_enrage = "Kurinnaxx is Enraged!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Kurinnaxx",
+
+    wound_cmd = "wound",
+    wound_name = "重伤警报",
+    wound_desc = "重伤出现时进行警告",
+
+    trap_cmd = "trap",
+    trap_name = "陷阱警报",
+    trap_desc = "为每个中陷阱的玩家显示计时条",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+    
+    trigger_trap = "流沙陷阱的沙漠陷阱击中(.+)造成", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    msg_sandTrap = "沙尘陷阱",
+    bar_trap = " 沙尘陷阱",
+    
+    trigger_woundYou = "你受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_woundOther = "(.+)受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_wound = " 重伤",
+
+    trigger_enrage = "库林纳克斯获得了狂怒的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "库林纳克斯激怒了！",
+    you = "你",
+} end )
 local timer = {
 	wound = 15,
 	trap = 20,

--- a/Raids/AQ20/Moam.lua
+++ b/Raids/AQ20/Moam.lua
@@ -30,6 +30,34 @@ L:RegisterTranslations("enUS", function() return {
 	msg_energizeFade = "Moam unparalyzed! 90 seconds until Mana Fiends!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Moam",
+
+	adds_cmd = "adds",
+    adds_name = "法力恶魔警报",
+    adds_desc = "法力恶魔出现时进行警告",
+
+	paralyze_cmd = "paralyze",
+    paralyze_name = "麻痹警报",
+    paralyze_desc = "麻痹出现时进行警告",
+
+
+	trigger_start = "%s感觉到了你的恐惧。",
+	
+	trigger_adds = " 耗尽你的法力并变成石头。",
+    bar_adds = "小怪",
+    msg_incoming = "法力恶魔即将在 %s 秒内到来！",
+    msg_adds = "法力恶魔已出现！莫阿姆麻痹 90 秒！",
+	
+	trigger_energyzeFade = "充能效果从莫阿姆身上消失",
+	trigger_energyzeFade2 = "充满了能量！",
+    bar_paralyse = "麻痹",
+    msg_energizeFadeSoon = "莫阿姆在 %s 秒后解除麻痹！",
+    msg_energizeFade = "莫阿姆解除麻痹！90 秒后出现法力恶魔！",
+} end )
 local timer = {
 	paralyze = 90,
 	unparalyze = 90,

--- a/Raids/AQ20/Ossirian.lua
+++ b/Raids/AQ20/Ossirian.lua
@@ -63,6 +63,66 @@ L:RegisterTranslations("enUS", function() return {
 	firstcrystal_warn = "CLICK IT NOW!!!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Ossirian",
+	
+    bigicon_cmd = "bigicon",
+    bigicon_name = "大图标警告标志",
+    bigicon_desc = "沙尘暴、虚弱和萨满的根基图腾的大警告标志",
+
+	warstomp_cmd = "warstomp",
+	warstomp_name = "战争践踏计时条",
+	warstomp_desc = "奥斯里安的战争践踏计时条",
+
+	cyclone_cmd = "cyclone",
+	cyclone_name = "飓风术计时条",
+	cyclone_desc = "奥斯里安的飓风术计时条",
+
+	sandstorm_cmd = "sandstorm",
+	sandstorm_name = "沙尘暴伤害警告",
+	sandstorm_desc = "受到沙尘暴的伤害时进行警告",
+	
+	supreme_cmd = "supreme",
+	supreme_name = "狂暴警报",
+	supreme_desc = "狂暴姿态出现时进行警告",
+	
+	weakness_cmd = "weakness",
+	weakness_name = "奥斯里安的弱点警报",
+	weakness_desc = "警告奥斯里安的新弱点是什么",
+
+	clickit_cmd = "clickit",
+	clickit_name = "现在点击水晶",
+	clickit_desc = "计时器，如果在此计时器后点击，他将变为狂暴状态",
+
+	supreme_trigger = "无疤者奥斯里安获得了奥斯里安之力的效果。",
+	supreme_trigger2 = "无疤者奥斯里安受到了奥西里安之力的影响。",
+	supreme_bar = "狂暴姿态",
+	supremewarn = "无疤者奥斯里安狂暴姿态!",
+	supremedelaywarn = "狂暴将在 %d 秒后出现！",
+
+	debuff_trigger = "无疤者奥斯里安受到了(.+)虚弱效果的影响。",
+	debuff_trigger2 = "无疤者奥斯里安获得了(.+)虚弱的效果。",
+	debuffwarn = "奥斯里安现在弱点是：",
+
+	ossiLostSupreme = "无疤者奥斯里安的奥斯里安之力效果消失了。",-- CHAT_MSG_SPELL_AURA_GONE_OTHER",
+
+	expose = "虚弱",
+	
+	cyclone_trigger = "包围之风",
+	cyclone_bar = "飓风术",
+	warstomp_trigger = "战争践踏",
+	warstomp_bar = "战争践踏",
+	
+	sandstorm_trigger = "沙尘漩涡的强风击中你造成",
+	
+	clickit_bar = "点击水晶或死亡",
+
+	firstcrystal_bar = "在0秒时点击第一个水晶",
+	firstcrystal_warn = "现在点击它！！！",
+} end )
 local timer = {
 	weakness = 45,
 	supreme = 45,

--- a/Raids/AQ40/Brainwasher.lua
+++ b/Raids/AQ40/Brainwasher.lua
@@ -36,6 +36,35 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "BrainWasher",
+
+    mc_cmd = "mc",
+    mc_name = "精神控制警报",
+    mc_desc = "精神控制出现时进行警告",
+
+    mindflay_cmd = "mindflay",
+    mindflay_name = "心灵震爆警报",
+    mindflay_desc = "心灵震爆出现时进行警告",
+
+
+    trigger_mcYou = "You are afflicted by Cause Insanity.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mcOther = "(.+) is afflicted by Cause Insanity.",--CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_mcFade = "Cause Insanity fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mc = " 精神控制",
+
+    trigger_mindFlayYou = "你受到了精神鞭笞效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mindFlayOther = "(.+)受到了精神鞭笞效果的影响。",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_mindFlayFade = "精神鞭笞效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mindFlay = " 精神鞭笞（死缠效果）",
+
+    ["You have slain %s!"] = "你已经击败了%s！",
+    clickme = " >点击我<",
+    you = "你",
+} end )
 local timer = {
 	mc = 10,
 	mindFlay = 8,

--- a/Raids/AQ40/BugFamily.lua
+++ b/Raids/AQ40/BugFamily.lua
@@ -87,6 +87,82 @@ L:RegisterTranslations("enUS", function() return {
 	msg_vemDead = "Vem is Dead - ENRAGE!",	
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "BugFamily",
+
+    panic_cmd = "panic",
+    panic_name = "恐惧",
+    panic_desc = "警告亚尔基公主的恐慌技能。",
+
+    volley_cmd = "volley",
+    volley_name = "毒性箭雨",
+    volley_desc = "警告克里勋爵的毒性箭雨。",
+
+    heal_cmd = "heal",
+    heal_name = "强效治疗",
+    heal_desc = "警告亚尔基公主的治疗。",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒",
+    enrage_desc = "激怒计时器。",
+
+    vapors_cmd = "vapors",
+    vapors_name = "毒云警报",
+    vapors_desc = "警告你是否站在毒性蒸汽中。",
+
+    deathspecials_cmd = "deathspecials",
+    deathspecials_name = "死亡特效",
+    deathspecials_desc = "让人们知道哪个Boss被杀死以及他们具有的特殊能力。",
+
+
+    trigger_panic = "受到了恐慌效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_panicResist = "恐慌被抵抗了。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+    trigger_panicImmune = "恐慌施放失败。(.+)对此免疫。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_panic = "恐慌 CD",
+
+    trigger_volleyHit = "毒性箭雨击中",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    trigger_volleyAfflicted = "受到了毒性箭雨效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_volleyResist = "毒性箭雨被抵抗了",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+    trigger_volleyImmune = "毒性箭雨施放失败",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_volley = "毒性箭雨",
+
+    trigger_heal = "亚尔基公主开始施放强效治疗术。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_heal = "强效治疗",
+    msg_heal = "亚尔基正在施放治疗 - 打断它！",
+	
+	trigger_attack1 = "亚尔基公主发起攻击", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack2 = "亚尔基公主没有击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack3 = "亚尔基公主击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_attack4 = "亚尔基公主的致命一击", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_kick1 = "脚踢击中亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_kick2 = "脚踢对亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_kick3 = "脚踢被亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_pummel1 = "拳击击中亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_pummel2 = "拳击对亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_pummel3 = "拳击被亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_shieldBash1 = "盾击击中亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_shieldBash2 = "盾击对亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_shieldBash3 = "盾击被亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_earthShock1 = "地震术击中亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	trigger_earthShock2 = "地震术致命一击对亚尔基公主", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+	
+    trigger_enrage = "%s进入了狂暴状态！",--CHAT_MSG_MONSTER_EMOTE (not confirmed)
+    bar_enrage = "狂暴",
+    msg_enrage60 = "60秒后狂暴！",
+    msg_enrage10 = "10秒后狂暴！",
+    msg_enrage = "狂暴了！",
+
+    trigger_toxicVapors = "你受到(%d+)点自然伤害（克里勋爵的毒性蒸汽）。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+   trigger_toxicVaporsFade = "毒性蒸汽效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_toxicVapors = "远离毒云！",
+
+    msg_kriDead = "克里勋爵死了 - 毒云！",
+    msg_yaujDead = "亚尔基公主死了 - 杀死幼虫！",
+    msg_vemDead = "维姆死了 - 复仇！",
+} end )
 local timer = {
 	earliestFirstPanic = 10,
 	latestFirstPanic = 20,

--- a/Raids/AQ40/Champion.lua
+++ b/Raids/AQ40/Champion.lua
@@ -23,6 +23,22 @@ L:RegisterTranslations("enUS", function() return {
 	bar_fear = "Intimidating Shout CD",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Champion",
+
+    fear_cmd = "fear",
+    fear_name = "破胆怒吼警报",
+    fear_desc = "破胆怒吼出现时进行警告",
+
+
+    trigger_fear = "afflicted by Intimidating Shout", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_fear2 = "Qiraji Champion's Intimidating Shout was resisted", --to be confirmed
+    trigger_fear3 = "Qiraji Champion's Intimidating Shout fail", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    bar_fear = "破胆怒吼 CD",
+} end )
 local timer = {
 	fearCd = {19,40},--saw 19, saw 40
 }

--- a/Raids/AQ40/Cthun.lua
+++ b/Raids/AQ40/Cthun.lua
@@ -150,6 +150,120 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Cthun",
+	
+	cthuneyebeam_cmd = "cthuneyebeam",
+    cthuneyebeam_name = "克苏恩的眼棱警报",
+    cthuneyebeam_desc = "克苏恩的眼棱出现时进行警告",
+	
+	darkglare_cmd = "darkglare",
+    darkglare_name = "黑暗闪耀警报",
+    darkglare_desc = "黑暗闪耀出现时进行警告",
+	
+	smalltentacle_cmd = "smalltentacle",
+    smalltentacle_name = "小眼触须警报",
+    smalltentacle_desc = "小眼触须出现时进行警告",
+	
+	smallclaw_cmd = "smallclaw",
+    smallclaw_name = "小爪子警报",
+    smallclaw_desc = "小爪触须出现时进行警告",
+	
+	gianttimer_cmd = "gianttimer",
+    gianttimer_name = "巨型利爪触须/眼睛刷新警报",
+    gianttimer_desc = "巨型利爪触须和巨眼触须刷新时进行警告",
+	
+	gianteyeeyebeam_cmd = "gianteyeeyebeam",
+    gianteyeeyebeam_name = "巨眼眼棱警报",
+    gianteyeeyebeam_desc = "巨眼眼棱出现时进行警告",
+	
+	groundtremor_cmd = "groundtremor",
+    groundtremor_name = "大地震颤警报",
+    groundtremor_desc = "大地震颤出现时进行警告",
+	
+	window_cmd = "window",
+    window_name = "机会窗口警报",
+    window_desc = "提示最佳削弱时机",
+	
+	weakened_cmd = "weakened",
+    weakened_name = "虚弱状态警报",
+    weakened_desc = "虚弱状态出现时进行警告",
+	
+	acid_cmd = "acid",
+    acid_name = "消化酸液警报",
+    acid_desc = "消化酸层数过高时进行警告",
+	
+	stomachhp_cmd = "stomachhp",
+    stomachhp_name = "胃部触须血量",
+    stomachhp_desc = "显示胃部触须的血量条和警告",
+	
+	proximity_cmd = "proximity",
+    proximity_name = "距离警告框",
+    proximity_desc = "显示距离警告框",
+	
+	stomachplayers_cmd = "stomachplayers",
+    stomachplayers_name = "胃部玩家框体",
+    stomachplayers_desc = "显示胃部的玩家框体",
+	
+	raidicon_cmd = "raidicon",
+    raidicon_name = "在眼棱目标上标记骷髅",
+    raidicon_desc = "在眼棱目标上标记骷髅",
+	
+	
+    bar_startRandomBeams = "随机眼棱开始！",
+
+	trigger_cthun_eyeBeam = "克苏恩之眼开始施放眼棱。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_eyeBeam = "眼棱即将攻击 ",
+	
+	--no dark glare trigger
+    bar_darkGlareCd = "下一次黑暗闪耀（红光）",
+    bar_darkGlareCasting = "正在施放黑暗闪耀！",
+    bar_darkGlareDur = "黑暗闪耀！",
+    msg_darkGlareCasting = "黑暗闪耀！",
+    msg_darkGlareEndsSoon = "黑暗闪耀将在5秒内结束",
+	
+	trigger_smallEyeTentacles = "眼球触须开始施放出生。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_smallEyeTentaclesSoon = "小眼触须将在3秒内出现",
+	bar_smallEyeTentacles = "小眼触须",
+	bar_smallEyesDead = "/8 小眼触须已死",
+	
+	trigger_smallClaw = "利爪触须开始施放出生。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_smallClaw = "小爪刷新",
+
+    msg_phase2 = "眼睛已死 - 本体即将出现！",
+	
+	trigger_giantClaw = "巨型利爪触须开始施放出生。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_giantClaw = "巨型利爪触须刷新",
+	
+	trigger_giantEye = "巨眼触须开始施放出生。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_giantEye = "巨眼触须刷新",
+	
+	trigger_giantEye_eyeBeam = "巨眼触须开始施放眼棱。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	--bar_eyeBeam = "Eye Beam on ",
+	
+	trigger_groundTremor = "受到了大地震颤效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_groundTremorDur = "大地震颤昏迷",
+	
+    bar_windowOfOpportunity = "机会窗口",
+	
+		--must be a string.find
+	trigger_weakened = "被削弱了！", --CHAT_MSG_MONSTER_EMOTE
+    bar_weakened = "虚弱时间，全力输出！",
+    msg_weakened = "克苏恩虚弱了！",
+    msg_weakenedFade = "虚弱结束",
+	
+	trigger_digestiveAcid = "你受到了消化酸液效果的影响%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_digestiveAcid = " 消化酸层数过高 - 考虑离开胃部",
+	
+    hpBar_firstTentacle = "第一个触须",
+    hpBar_secondTentacle = "第二个触须",
+    msg_firstTentacleDead = "第一个触须已死",
+	
+    frameHeader_playersInStomach = "胃部玩家",
+} end )
 local timer = {
 	p1_startRandomBeams = 8,
 	eyeBeamCast = 2,

--- a/Raids/AQ40/Defenders.lua
+++ b/Raids/AQ40/Defenders.lua
@@ -88,6 +88,87 @@ L:RegisterTranslations("enUS", function()
 		msg_enrage = "Enraged!",
 	}
 end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Defender",
+	
+	reflect_cmd = "reflect",
+    reflect_name = "法术反射警报",
+    reflect_desc = "显示防御者拥有的反射法术的计时条",
+
+    plague_cmd = "plague",
+    plague_name = "瘟疫警报",
+    plague_desc = "瘟疫出现时进行警告",
+
+    icon_cmd = "icon",
+    icon_name = "瘟疫团队标记",
+    icon_desc = "在最后一个被瘟疫感染的人身上放置团队标记（需要助理或更高权限）",
+
+    thunderclap_cmd = "thunderclap",
+    thunderclap_name = "雷霆一击警报",
+    thunderclap_desc = "雷霆一击出现时进行警告",
+
+    shadowstorm_cmd = "shadowstorm",
+    shadowstorm_name = "暗影风暴警报",
+    shadowstorm_desc = "暗影风暴出现时进行警告",
+
+    meteor_cmd = "meteor",
+    meteor_name = "流星警报",
+    meteor_desc = "流星出现时进行警告",
+
+    explode_cmd = "explode",
+    explode_name = "爆炸警报",
+    explode_desc = "爆炸出现时进行警告",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+	
+	
+	trigger_arcaneFireReflect1 = "月火术被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect2 = "灼烧被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect3 = "烈焰震击被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect4 = "火球术被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect5 = "烈焰鞭笞被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_arcaneFireReflect6 = "侦测魔法被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+    bar_fireArcaneReflect = "火焰 & 奥术反射",
+	
+	trigger_shadowFrostReflect1 = "暗言术：痛被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect2 = "腐蚀术被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect3 = "寒冰箭被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect4 = "冰霜震击被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_SELF_DAMAGE
+	trigger_shadowFrostReflect5 = "阿努比萨斯防御者受到了侦测魔法效果的影响。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    bar_shadowFrostReflect = "暗影 & 冰霜反射",
+	
+	trigger_selfReflect = "你的(.*)被阿努比萨斯防御者反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_selfReflect = "法术反射 - 停止自残！",
+	
+	trigger_plagueYou = "你受到了瘟疫效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_plagueOther = "(.+)受到了瘟疫效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_plague = "瘟疫",
+    msg_plague = "瘟疫在 ",
+	
+	trigger_thunderClap = "阿努比萨斯防御者的雷霆震击", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_thunderClap = "雷霆一击",
+    msg_thunderClap = "雷霆一击 - 远程远离！",
+
+	trigger_shadowStorm = "阿努比萨斯防御者的暗影风暴", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_shadowStorm = "暗影风暴",
+    msg_shadowStorm = "暗影风暴 - 远程靠近！",
+
+	trigger_meteor = "阿努比萨斯防御者的流星", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_meteor = "流星",
+    msg_meteor = "流星！",
+	
+	trigger_explode = "阿努比萨斯防御者获得了爆炸的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_explode = "即将爆炸！",
+    msg_explode = "即将爆炸！快跑！！！",
+
+	trigger_enrage = "阿努比萨斯防御者获得了狂怒的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "狂暴！加大治疗！",
+} end )
 local timer = {
 	--the timers for tClap, sStorm, meteor vary too much,
 	--will just put 600 so bars tell people what abilities they have

--- a/Raids/AQ40/Fankriss.lua
+++ b/Raids/AQ40/Fankriss.lua
@@ -27,7 +27,29 @@ L:RegisterTranslations("enUS", function() return {
 	bar_wound = " Wounds",
 } end )
 
-
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Fankriss",
+	
+	wound_cmd = "wound",
+    wound_name = "重伤堆叠5层警报",
+    wound_desc = "当重伤达到5层时进行警报",
+    
+    entangle_cmd = "entangle",
+    entangle_name = "纠缠警报",
+    entangle_desc = "纠缠出现时进行警告",
+	
+	
+	trigger_entangleYou = "你受到了纠缠效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_entangleOther = "(.+)受到了纠缠效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_entangleFade = "纠缠效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_entangle = " 纠缠持续",
+	
+	trigger_woundYou = "你受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_woundOther = "(.+)受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_wound = " 重伤持续",
+} end )
 local timer = {
 	entangle = 8,
 	wound = 15,

--- a/Raids/AQ40/Huhuran.lua
+++ b/Raids/AQ40/Huhuran.lua
@@ -60,6 +60,59 @@ L:RegisterTranslations("enUS", function() return {
 	msg_enrage5sec = "Enrage in 5 seconds",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Huhuran",
+
+    wyvernsting_cmd = "wyvernsting",
+    wyvernsting_name = "飞龙钉刺警报",
+    wyvernsting_desc = "飞龙钉刺出现时进行警告",
+
+    frenzy_cmd = "frenzy",
+    frenzy_name = "狂乱警报",
+    frenzy_desc = "狂乱出现时进行警告",
+
+    noxiouspoison_cmd = "noxiouspoison",
+    noxiouspoison_name = "剧毒警报",
+    noxiouspoison_desc = "剧毒出现时进行警告",
+    
+    berserk_cmd = "berserk",
+    berserk_name = "低血量狂暴警报",
+    berserk_desc = "低血量狂暴出现时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "定时狂怒警报",
+    enrage_desc = "定时狂怒出现时进行警告",
+    
+    
+    trigger_wyvernSting = "受到了翼龙钉刺效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_wyvernStingYou = "受到了翼龙钉刺效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_wyvernStingYouFade = "翼龙钉刺效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_wyvernStingDuration = "翼龙钉刺效果",
+    bar_wyvernStingCd = "翼龙钉刺冷却",
+    
+    trigger_frenzyGain = "哈霍兰公主获得了疯狂的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_frenzyFade = "疯狂效果从哈霍兰公主身上消失。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_frenzyDuration = "狂乱！",
+    bar_frenzyCd = "狂乱冷却",
+    msg_frenzy = "狂乱 - 宁神射击！",
+
+    trigger_noxiousPoison = "受到了致命剧毒效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_noxiousPoisonYou = "你受到了致命剧毒效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_noxiousPoisonYouFade = "致命剧毒效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_noxiousPoisonDuration = "沉默效果",
+    bar_noxiousPoisonCd = "剧毒冷却",
+    
+    trigger_berserk = "哈霍兰公主获得了狂暴的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_berserk = "狂暴！开管家铃！召唤各种小弟！",
+    
+    trigger_enrage = "哈霍兰公主获得了狂怒的效果。",--5min timer, string to be confirmed
+    bar_enrage = "狂怒",
+    msg_enrage1min = "60秒内狂怒",
+    msg_enrage5sec = "5秒内狂怒",
+} end )
 local timer = {
 	wyvernStingCdFirst = {18,28},
 	wyvernStingCd = {3,20},--15,32 minus 12sec duration

--- a/Raids/AQ40/Mindslayer.lua
+++ b/Raids/AQ40/Mindslayer.lua
@@ -44,6 +44,44 @@ L:RegisterTranslations("enUS", function() return {
 	["You have slain %s!"] = true,
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Mindslayer",
+
+    mc_cmd = "mc",
+    mc_name = "精神控制警报",
+    mc_desc = "精神控制出现时进行警告",
+
+    mindflay_cmd = "mindflay",
+    mindflay_name = "精神鞭笞警报",
+    mindflay_desc = "精神鞭笞出现时进行警告",
+
+    disorient_cmd = "disorient",
+    disorient_name = "法力燃烧&迷惑警报",
+    disorient_desc = "法力燃烧&迷惑出现时进行警告",
+
+
+    trigger_mcYou = "You are afflicted by Cause Insanity.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mcOther = "(.+) is afflicted by Cause Insanity.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_mcFade = "Cause Insanity fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mc = " 精神控制",
+    msg_mc = "精神控制在 ",
+
+    trigger_mindFlayYou = "You are afflicted by Mind Flay.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mindFlayOther = "(.*) is afflicted by Mind Flay.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_mindFlayFade = "Mind Flay fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mindFlay = " 精神鞭笞",
+
+    trigger_disorient = "afflicted by Mana Burn.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    bar_disorient = "法力燃烧&迷惑",
+    msg_disorientSoon = "其拉斩灵者血量 < 20% HP - 即将出现30码范围法力燃烧&迷惑！",
+
+    ["You have slain %s!"] = "你已经击败了%s！",
+    clickme = " >点击我！<",
+    you = "你",
+} end )
 local timer = {
 	mc = 9.5,
 	mindFlay = 8,

--- a/Raids/AQ40/Ouro.lua
+++ b/Raids/AQ40/Ouro.lua
@@ -63,6 +63,66 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_popcornHitsYou = "Dirt Mound's Quake hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Ouro",
+
+    sweep_cmd = "sweep",
+    sweep_name = "横扫警报",
+    sweep_desc = "奥罗横扫出现时进行警告",
+
+    sandblast_cmd = "sandblast",
+    sandblast_name = "沙尘爆裂警报",
+    sandblast_desc = "沙尘爆裂出现时进行警告",
+
+    popcorn_cmd = "popcorn",
+    popcorn_name = "爆裂物警报",
+    popcorn_desc = "受到爆裂物伤害时进行警告",
+
+    emerge_cmd = "emerge",
+    emerge_name = "浮现/下潜警报",
+    emerge_desc = "奥罗浮现或下潜时进行警告",
+
+    berserk_cmd = "berserk",
+    berserk_name = "狂暴警报",
+    berserk_desc = "奥罗进入狂暴状态时进行警告",
+
+    targeticon_cmd = "targeticon",
+    targeticon_name = "奥罗目标头上的骷髅标记",
+    targeticon_desc = "在奥罗的目标头上标记骷髅团队标志",
+	
+	
+    trigger_engage = "奥罗开始施放出生。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    
+    trigger_sweep = "奥罗开始施放横扫。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_sweepCd = "横扫 CD",
+    bar_sweepCast = "横扫！",
+    msg_sweep = "正在施放横扫！",
+    
+    trigger_sandBlast = "奥罗开始施展沙尘爆裂。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_sandBlastCd = "沙尘爆裂 CD",
+    bar_sandBlastCast = "沙尘爆裂！快跑！",
+    msg_sandBlast = "正在施放沙尘爆裂！",
+
+    trigger_emerge = "大地破裂", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_submergePossible = "可能下潜",
+    msg_emerge = "奥罗已浮现！",
+    
+    --there is no trigger_submerge
+    bar_submergeDuration = "奥罗浮现",
+    msg_submerge = "奥罗已下潜！",
+    msg_collapse = "10秒后奥罗浮现 - 向中部集合！",
+    
+    trigger_berserk = "奥罗获得了狂暴的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_berserk = "奥罗进入狂暴状态 - 不再下潜",
+    msg_berserkSoon = "即将狂暴 - 准备！",
+    
+    bar_berserkPopcorn = "新的爆裂物出现", --10sec after enrage, should be 1 per 10sec afterwards
+
+    trigger_popcornHitsYou = "土堆的地震击中你", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+} end )
 local timer = {
 	firstSweep = {20.5,25},
 	sweepCd = 20.5,

--- a/Raids/AQ40/Sartura.lua
+++ b/Raids/AQ40/Sartura.lua
@@ -50,6 +50,52 @@ L:RegisterTranslations("enUS", function() return {
 	msg_berserk10 = "Berserk in 10 seconds!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Sartura",
+
+    adds_cmd = "adds",
+    adds_name = "萨特拉的皇家卫兵死亡计数器",
+    adds_desc = "宣布萨特拉的皇家卫兵死亡。",
+
+    whirlwind_cmd = "whirlwind",
+    whirlwind_name = "旋风斩",
+    whirlwind_desc = "旋风斩的计时器和计时条。",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒",
+    enrage_desc = "在Boss血量为20%时警告激怒。",
+
+    berserk_cmd = "berserk",
+    berserk_name = "狂暴",
+    berserk_desc = "警告Boss在10分钟后获得的狂暴。",
+
+
+    trigger_engage = "你将因玷污这些神圣的土地而受到审判！上古法则不容挑战！入侵者将被消灭！", --CHAT_MSG_MONSTER_YELL
+    trigger_bossDead = "我服务到最后！", --CHAT_MSG_MONSTER_YELL
+
+    trigger_addDead = "沙尔图拉皇家卫士死亡了。", --CHAT_MSG_COMBAT_HOSTILE_DEATH
+    msg_addDead = "%d/3 沙尔图拉皇家卫士死亡！",
+
+    trigger_whirlwind = "沙尔图拉获得了旋风斩的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_whirlwind = "旋风斩！",
+    msg_whirlwind = "旋风斩！",
+    bar_whirlwindCd = "旋风斩 CD",
+
+    trigger_whirlwindFade = "Whirlwind fades from Battleguard Sartura.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_whirlwindFade = "旋风斩结束！",
+
+    trigger_enrage = "沙尔图拉生气了！", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "激怒 - 疯狂治疗！",
+
+    trigger_berserk = "沙尔图拉陷入狂暴状态！", --to be confirmed
+    msg_berserk = "狂暴！",
+    bar_berserk = "狂暴",
+    msg_berserk60 = "60秒后狂暴！",
+    msg_berserk10 = "10秒后狂暴！",
+} end )
 local timer = {
 	firstWhirlwind = {8,12},
 	whirlwindCd = {5,10},

--- a/Raids/AQ40/Sentinels.lua
+++ b/Raids/AQ40/Sentinels.lua
@@ -68,6 +68,67 @@ L:RegisterTranslations("enUS", function() return {
 	["You have slain %s!"] = true,
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Sentinel",
+
+    abilities_cmd = "abilities",
+    abilities_name = "技能警报",
+    abilities_desc = "技能出现时进行警告",
+
+    selfreflect_cmd = "selfreflect",
+    selfreflect_name = "自身反射法术警报",
+    selfreflect_desc = "当法术被反射回自己时进行警告",
+
+
+    bar_knockBack = " 有击退",
+    buffIcon_knockBack = "Interface\\Icons\\Ability_UpgradeMoonGlaive",
+
+    bar_manaBurn = " 有法力燃烧",
+    buffIcon_manaBurn = "Interface\\Icons\\Spell_Shadow_ManaBurn",
+
+    bar_mending = " 有治愈",
+    buffIcon_mending = "Interface\\Icons\\Spell_Nature_ResistNature",
+
+    bar_mortalStrike = " 有致死打击",
+    buffIcon_mortalStrike = "Interface\\Icons\\Ability_Warrior_SavageBlow",
+
+    bar_shadowStorm = " 有暗影风暴",
+    buffIcon_shadowStorm = "Interface\\Icons\\Spell_Shadow_Haunting",
+
+    bar_thorns = " 有荆棘术",
+    buffIcon_thorns = "Interface\\Icons\\Spell_Nature_Thorns",
+
+    bar_thunderClap = " 有雷霆一击",
+    buffIcon_thunderClap = "Interface\\Icons\\Ability_ThunderClap",
+
+    trigger_fireArcaneReflect1 = "你的月火术被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflect2 = "你的灼烧被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflect3 = "你的烈焰震击被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflect4 = "你的火球术被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflect5 = "你的烈焰鞭笞被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflect6 = "你的侦测魔法被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_fireArcaneReflectOther = "(.+)的侦测魔法被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE
+    bar_fireArcaneReflect = " 反射火焰 & 奥术",
+        --not used for TurtleWoW
+    --buffIcon_fireArcaneReflect = "nil",
+    
+    trigger_shadowFrostReflect1 = "你的暗言术：痛被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_shadowFrostReflect2 = "你的腐蚀术被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_shadowFrostReflect3 = "你的寒冰箭被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_shadowFrostReflect4 = "你的冰霜震击被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_shadowFrostReflectOther = "(.+)的腐蚀术被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE
+    bar_shadowFrostReflect = " 反射暗影 & 冰霜",
+        --not used for TurtleWoW
+    --buffIcon_shadowFrostReflect = "Interface\\Icons\\Spell_Arcane_Blink",
+    
+    trigger_selfReflect = "你的(.*)被阿努比萨斯哨兵反弹回来。",--CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_selfReflect = "停止自残！",
+    
+    ["You have slain %s!"] = "你杀死了%s！",
+} end )
 local timer = {
 	knockBack = 600,
 	manaBurn = 600,

--- a/Raids/AQ40/Skeram.lua
+++ b/Raids/AQ40/Skeram.lua
@@ -33,6 +33,35 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Skeram",
+
+    mc_cmd = "mc",
+    mc_name = "精神控制警报",
+    mc_desc = "精神控制出现时进行警告",
+
+    split_cmd = "split",
+    split_name = "分裂警报",
+    split_desc = "分裂前进行警告",
+    
+    trigger_mcYou = "You are afflicted by True Fulfillment.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE (unconfirmed)
+    trigger_mcOther = "(.+) is afflicted by True Fulfillment.",--CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    trigger_mcFade = "True Fulfillment fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_mc = " 被精神控制，快羊他！",
+    bar_mc = " 精神控制",
+    
+    trigger_kill = "You only delay... the inevetable.",--CHAT_MSG_MONSTER_YELL
+
+    split_message = "分裂！",
+    kill_trigger = "You only delay",
+
+    ["You have slain %s!"] = "你已经击败了%s！",
+    you = "你",
+    clickme = " >点击我！<",
+} end )
 local timer = {
 	mc = 20,
 }

--- a/Raids/AQ40/Twins.lua
+++ b/Raids/AQ40/Twins.lua
@@ -78,6 +78,65 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Twins",
+    
+    teleport_cmd = "teleport",
+    teleport_name = "传送警报",
+    teleport_desc = "传送出现时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+    blizzard_cmd = "blizzard",
+    blizzard_name = "暴风雪警报",
+    blizzard_desc = "暴风雪出现时进行警告",
+
+    heal_cmd = "heal",
+    heal_name = "治疗警报",
+    heal_desc = "双子治疗时进行警告",
+    
+    targeticon_cmd = "targeticon",
+    targeticon_name = "双子目标团队标志",
+    targeticon_desc = "给施法的双子目标标一个星星，给近战的双子目标标一个骷髅",
+    
+    
+    trigger_tp = "获得了双子传送的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_tpCd = "传送冷却",
+    bar_tpOffCd = "传送准备...",
+    msg_tpOffCd = "10秒内传送！",
+    
+    trigger_enrage = "Emperor Vek'nilash becomes enraged.",--??
+    trigger_enrage2 = "Emperor Vek'lor becomes enraged.",--??
+    bar_enrage = "狂暴",
+    msg_enrage60 = "60秒后狂暴",
+    msg_enrage10 = "10秒后狂暴",
+    msg_enrage = "双子狂暴了",
+    
+    trigger_blizzard = "你受到了暴风雪效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_blizzardFade = "暴风雪效果从你身上消失。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_blizzard = "远离暴风雪！",
+    
+    trigger_heal = "治疗兄弟",--??
+    msg_heal = "两个BOSS距离太近，快分开他们！",
+
+    pull_trigger1 = "啊，待宰的羔羊！",
+    pull_trigger2 = "Prepare to embrace oblivion!",
+    pull_trigger3 = "兄弟，跟我一起，流血吧！",
+    pull_trigger4 = "To decorate our halls.",
+    pull_trigger5 = "不让任何人活下来！",
+    pull_trigger6 = "转身离开已经太晚了。",
+    pull_trigger7 = "看兄弟，新鲜血液！",
+    pull_trigger8 = "Like a fly in a web.",
+    pull_trigger9 = "Shall be your undoing!",
+    pull_trigger10 = "Your brash arrogance",
+
+    kill_trigger = "我的兄弟...不！",
+} end )
 local timer = {
 	tpInterval = {30,40},
 	tpReady = 10,

--- a/Raids/AQ40/Viscidus.lua
+++ b/Raids/AQ40/Viscidus.lua
@@ -66,6 +66,69 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Viscidus",
+
+    volley_cmd = "volley",
+    volley_name = "毒箭齐射警报",
+    volley_desc = "毒箭齐射出现时进行警告",
+
+    toxin_cmd = "toxin",
+    toxin_name = "站在毒云中警报",
+    toxin_desc = "站在毒云中时进行警告",
+
+    freezestages_cmd = "freezestages",
+    freezestages_name = "冰冻状态警报",
+    freezestages_desc = "不同冰冻状态时进行警告",
+    
+    freezecount_cmd = "freezecount",
+    freezecount_name = "计算冰霜伤害",
+    freezecount_desc = "计算冰霜伤害击中维希度斯的次数以冻结它",
+    
+    pokecount_cmd = "pokecount",
+    pokecount_name = "计算戳击伤害",
+    pokecount_desc = "计算物理伤害击中维希度斯的次数以使其粉碎",
+    
+    glob_cmd = "glob",
+    glob_name = "水珠死亡计数器",
+    glob_desc = "计数水珠的死亡次数",
+
+
+    trigger_volley = "受到了毒箭之雨效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_volley = "毒箭齐射",
+    
+    trigger_toxin = "你受到了剧毒效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_toxin = "远离毒云！",
+    trigger_toxinFade = "剧毒效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER",
+
+    trigger_frostDmg = "冰霜伤害",--CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE
+    trigger_chilledDmg = "获得冰冻",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_wintersChill = "获得深冬之寒",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_frostDmg = "剩余冰霜击中次数",
+    
+    trigger_pokeYou = "击中维希度斯",--CHAT_MSG_COMBAT_SELF_HITS
+    trigger_pokeOther = "击中维希度斯",--CHAT_MSG_COMBAT_PARTY_HITS // CHAT_MSG_COMBAT_FRIENDLYPLAYER_HITS
+    trigger_pokeCritYou = "击中维希度斯",--CHAT_MSG_COMBAT_SELF_HITS
+    trigger_pokeCritOther = "击中维希度斯",--CHAT_MSG_COMBAT_PARTY_HITS // CHAT_MSG_COMBAT_FRIENDLYPLAYER_HITS
+    bar_poke = "剩余戳击次数",
+    
+    trigger_slow = "开始变慢！",--CHAT_MSG_RAID_BOSS_EMOTE
+    trigger_freezing = "冻僵了！",--CHAT_MSG_RAID_BOSS_EMOTE
+    trigger_frozen = "冻成固体了！",--CHAT_MSG_RAID_BOSS_EMOTE
+    trigger_crack = "开始破裂！",--CHAT_MSG_RAID_BOSS_EMOTE
+    trigger_shatter = "看起来就要崩溃了！",--CHAT_MSG_RAID_BOSS_EMOTE
+    
+    msg_slow = "冻结计数：100 / 200",
+    msg_freezing = "冻结计数：150 / 200",
+    msg_frozen = "冻结计数：200 / 200 - 已冻结，赶快戳击它！",
+    msg_crack = "戳击计数：50 / 150",
+    msg_shatter = "戳击计数：100 / 150",
+    
+    bar_glob = "剩余水珠数量",
+} end )
 local timer = {
 	volley = { 10, 15 },
 	toxin = 10,

--- a/Raids/AQ40/Warder.lua
+++ b/Raids/AQ40/Warder.lua
@@ -52,6 +52,54 @@ L:RegisterTranslations("enUS", function() return {
 	msg_foundDust = "Dust - Next ability is Roots or Fear", --can't be Silence
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Warder",
+
+    fear_cmd = "fear",
+    fear_name = "恐惧警报",
+    fear_desc = "恐惧出现时进行警告",
+
+    silence_cmd = "silence",
+    silence_name = "沉默警报",
+    silence_desc = "沉默出现时进行警告",
+
+    roots_cmd = "roots",
+    roots_name = "缠绕根须警报",
+    roots_desc = "缠绕根须出现时进行警告",
+
+    dust_cmd = "dust",
+    dust_name = "尘雾之云警报",
+    dust_desc = "尘雾之云出现时进行警告",
+
+    warnings_cmd = "warnings",
+    warnings_name = "第二技能警告",
+    warnings_desc = "警告第二技能可能为何。",
+
+	
+    trigger_fear = "Anubisath Warder begins to cast Fear.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_fearCast = "恐惧！",
+    bar_fearCd = "恐惧 CD",
+
+    trigger_silence = "Anubisath Warder begins to cast Silence.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_silenceCast = "沉默！",
+    bar_silenceCd = "沉默 CD",
+
+    trigger_roots = "Anubisath Warder begins to cast Entangling Roots.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_rootsCast = "缠绕根须！",
+    bar_rootsCd = "缠绕根须 CD",
+
+    trigger_dust = "Anubisath Warder begins to perform Dust Cloud.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_dustCast = "尘雾之云！",
+    bar_dustCd = "尘雾之云 CD",
+    
+    msg_foundFear = "恐惧 - 下一个技能可能是沉默或尘雾之云", --can't be Roots
+    msg_foundSilence = "沉默 - 下一个技能可能是缠绕根须或恐惧", --can't be Dust
+    msg_foundRoots = "缠绕根须 - 下一个技能可能是沉默或尘雾之云", --can't be Fear
+    msg_foundDust = "尘雾之云 - 下一个技能可能是缠绕根须或恐惧", --can't be Silence
+} end )
 local timer = {
 	fearCd = {15,20}, --saw 15.4, 17.2, 20.5
 	fearCast = 1.5,

--- a/Raids/BlackMorass/Antnormi.lua
+++ b/Raids/BlackMorass/Antnormi.lua
@@ -41,6 +41,40 @@ L:RegisterTranslations("enUS", function() return {
 	msg_enrage = "Enrage!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Antnormi",
+
+    fear_cmd = "fear",
+    fear_name = "恐惧警报",
+    fear_desc = "恐惧出现时进行警告",
+    
+    shadowshock_cmd = "shadowshock",
+    shadowshock_name = "暗影震击警报",
+    shadowshock_desc = "暗影震击出现时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+    
+    trigger_engage = "We are Infinite!Your journey ends here now, time will belong to US!",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_fearCastStart = "is preparing for a bellowing roar!",--CHAT_MSG_RAID_BOSS_EMOTE
+    bar_fearCast = "正在施放恐惧",
+    
+    trigger_fearCastEnd = "afflicted by Cowering Roar",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_fearDuration = "恐惧中！",
+    bar_fearCd = "恐惧冷却",
+    
+    trigger_shadowShock = "Antnormi's Shadow Shock",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_FRIENDLYPLAYER_DAMAGE
+    bar_shadowShockCd = "暗影震击冷却",
+    
+    trigger_enrage = "Antnormi gains Enrage.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "激怒！",
+} end )
 local timer = {
 	firstFearCd = 20,
 	fearCd = 20,--25sec between each fear emote

--- a/Raids/BlackMorass/Chronar.lua
+++ b/Raids/BlackMorass/Chronar.lua
@@ -40,6 +40,40 @@ L:RegisterTranslations("enUS", function() return {
 	msg_enrage = "Enrage!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Chronar",
+
+    reflect_cmd = "reflect",
+    reflect_name = "法术反射警报",
+    reflect_desc = "法术反射出现时进行警告",
+    
+    ms_cmd = "ms",
+    ms_name = "致死打击警报",
+    ms_desc = "致死打击出现时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+    trigger_engage = "It seems we have visitors. You should not have come here mortals, now I will ensure that you will not leave.",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_reflect = "Chronar gains Reflection.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_reflectFade = "Reflection fades from Chronar.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_reflect = "法术反射",
+    msg_reflect = "克罗纳尔正在反射法术！",
+    
+    trigger_msOther = "(.+) is afflicted by Mortal Strike.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_msYou = "You are afflicted by Mortal Strike.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_msFade = "Mortal Strike fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_ms = "致死打击",
+    
+    trigger_enrage = "Chronar gains Enrage.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS",
+    msg_enrage = "激怒！",
+    you = "you",
+} end )
 local timer = {
 	reflect = 10,
 	ms = 5,

--- a/Raids/BlackMorass/DriftingAvatarOfSand.lua
+++ b/Raids/BlackMorass/DriftingAvatarOfSand.lua
@@ -22,6 +22,22 @@ L:RegisterTranslations("enUS", function() return {
 	bar_blindingSand = " Blinded",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "DriftingAvatarOfSand",
+
+    blindingsand_cmd = "blindingsand",
+    blindingsand_name = "致盲沙尘警报",
+    blindingsand_desc = "致盲沙尘出现时进行警告",
+    
+    trigger_blindingSandYou = "You are afflicted by Blinding Sand.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_blindingSandOther = "(.+) is afflicted by Blinding Sand.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_blindingSandFade = "Blinding Sand fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_blindingSand = "致盲",
+    you = "you",
+} end )
 local timer = {
 	blindingSand = 5,
 }

--- a/Raids/BlackMorass/Epidamu.lua
+++ b/Raids/BlackMorass/Epidamu.lua
@@ -31,6 +31,31 @@ L:RegisterTranslations("enUS", function() return {
 	bar_temporalConflux = " Temporal Conflux",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Epidamu",
+
+    drainmana_cmd = "drainmana",
+    drainmana_name = "法力吸取警报",
+    drainmana_desc = "法力吸取出现时进行警告",
+    
+    temporalconflux_cmd = "temporalconflux",
+    temporalconflux_name = "时空涡流警报",
+    temporalconflux_desc = "时空涡流出现时进行警告",
+
+    trigger_drainManaYou = "You are afflicted by Drain Mana.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_drainManaOther = "(.+) is afflicted by Drain Mana.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_drainManaFade = "Drain Mana fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_drainMana = "法力吸取",
+    
+    trigger_temporalConfluxYou = "You are afflicted by Temporal Conflux.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_temporalConfluxOther = "(.+) is afflicted by Temporal Conflux.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_temporalConfluxFade = "Temporal Conflux fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_temporalConflux = "时空涡流",
+    you = "you",
+} end )
 local timer = {
 	drainMana = 5,
 	temporalConflux = 15,

--- a/Raids/BlackMorass/Mossheart.lua
+++ b/Raids/BlackMorass/Mossheart.lua
@@ -48,6 +48,48 @@ L:RegisterTranslations("enUS", function() return {
 	msg_rejuvenation = "Mossheart gains Rejuvenation, Purge / Dispel!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Mossheart",
+
+    mosscoveredhands_cmd = "mosscoveredhands",
+    mosscoveredhands_name = "苔藓覆手警报",
+    mosscoveredhands_desc = "苔藓覆手出现时进行警告",
+    
+    entanglingroots_cmd = "entanglingroots",
+    entanglingroots_name = "纠缠根须警报",
+    entanglingroots_desc = "纠缠根须出现时进行警告",
+    
+    dredgesickness_cmd = "dredgesickness",
+    dredgesickness_name = "病弱警报",
+    dredgesickness_desc = "病弱出现时进行警告",
+    
+    rejuvenation_cmd = "rejuvenation",
+    rejuvenation_name = "回春术警报",
+    rejuvenation_desc = "回春术出现时进行警告",
+    
+    
+    trigger_engage = "Who dares defile the sanctity of the morass...",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_mossCoveredHandsYou = "You are afflicted by Moss Covered Hands.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mossCoveredHandsOther = "(.+) is afflicted by Moss Covered Hands.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_mossCoveredHandsFade = "Moss Covered Hands fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mossCoveredHands = "苔藓",
+    
+    trigger_entanglingRoots = "The very earth rises in defiance...",--CHAT_MSG_MONSTER_YELL
+    bar_entanglingRootsCd = "纠缠根须冷却",
+    
+    --50% and 25%? or timed 46sec from pull and 25sec after?
+    trigger_dredgeSickness = "afflicted by Dredge Sickness",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    
+    trigger_rejuvenation = "Mossheart gains Rejuvenation.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_rejuvenationFade = "Rejuvenation fades from Mossheart.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_rejuvenation = "回春术",
+    msg_rejuvenation = "莫斯哈特获得回春术，快驱散！",
+    you = "you",
+} end )
 local timer = {
 	mossCoveredHands = 180,
 	entanglingRootsCd = 25,

--- a/Raids/BlackMorass/Rotmaw.lua
+++ b/Raids/BlackMorass/Rotmaw.lua
@@ -32,6 +32,32 @@ L:RegisterTranslations("enUS", function() return {
 	bar_consume = " Consumed",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Rotmaw",
+
+    contagionofrot_cmd = "contagionofrot",
+    contagionofrot_name = "腐化传染警报",
+    contagionofrot_desc = "腐化传染出现时进行警告",
+    
+    consume_cmd = "consume",
+    consume_name = "吞噬警报",
+    consume_desc = "吞噬出现时进行警告",
+
+        
+    trigger_contagionOfRotYou = "You are afflicted by Contagion of Rot.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_contagionOfRotOther = "(.+) is afflicted by Contagion of Rot.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_contagionOfRotFade = "Contagion of Rot fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_contagionOfRot = "腐败之源",
+    
+    trigger_consumeYou = "You are afflicted by Consume.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_consumeOther = "(.+) is afflicted by Consume.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_consumeFade = "Consume fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_consume = "被吞噬",
+    you = "you",
+} end )
 local timer = {
 	contagionOfRot = 240,
 	consume = 15,

--- a/Raids/BlackMorass/TimeLordEpochronos.lua
+++ b/Raids/BlackMorass/TimeLordEpochronos.lua
@@ -65,6 +65,64 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "TimeLordEpochronos",
+
+    sandbreath_cmd = "sandbreath",
+    sandbreath_name = "沙尘之息警报",
+    sandbreath_desc = "沙尘之息出现时进行警告",
+    
+    banish_cmd = "banish",
+    banish_name = "放逐警报",
+    banish_desc = "放逐出现时进行警告",
+    
+    dnd_cmd = "dnd",
+    dnd_name = "死亡凋零警报",
+    dnd_desc = "死亡凋零出现时进行警告",
+    
+    devouringplague_cmd = "devouringplague",
+    devouringplague_name = "噬灵瘟疫警报",
+    devouringplague_desc = "噬灵瘟疫出现时进行警告",
+    
+    deathcoil_cmd = "deathcoil",
+    deathcoil_name = "死亡缠绕警报",
+    deathcoil_desc = "死亡缠绕出现时进行警告",
+    
+    
+    trigger_engage = "Time moves in our favor, your intrusion ends here!",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_sandBreath = "Time-Lord Epochronos begins to perform Sand Breath.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_sandBreathCast = "正在施放沙尘之息",
+    bar_sandBreathCd = "沙尘之息冷却",
+    
+    trigger_lkSpawn = "Time-Lord Epochronos is afflicted by Banish.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    trigger_banishFade = "Banish fades from Time-Lord Epochronos.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_banish = "放逐",
+    msg_banish = "击杀出现的小型Boss！",
+    
+    trigger_dndCast = "Echo of the Lich King begins to cast Death & Decay.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_dndCast = "正在施放死亡凋零",
+    msg_dndCast = "正在施放死亡凋零，打断！",
+    
+    --to be confirmed
+    trigger_dndDamage = "You suffer (.+) Shadow damage from Death & Decay.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    
+    trigger_devouringPlagueYou = "You are afflicted by Devouring Plague.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_devouringPlagueOther = "(.+) is afflicted by Devouring Plague.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_devouringPlagueFade = "Devouring Plague fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_devouringPlague = "噬灵瘟疫",
+    
+    trigger_deathCoilYou = "You are afflicted by Death Coil.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_deathCoilOther = "(.+) is afflicted by Death Coil.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    trigger_deathCoilFade = "Death Coil fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_deathCoil = "死亡缠绕",
+    
+    --Lady Vashj -> Thunderstorm Cloud -> CLOG
+    you = "you",
+} end )
 local timer = {
 	sandBreathCast = 2,
 	sandBreathCd = 13,

--- a/Raids/DireMaul/CaptainKromcrush.lua
+++ b/Raids/DireMaul/CaptainKromcrush.lua
@@ -42,6 +42,41 @@ L:RegisterTranslations("enUS", function() return {
 	addsUpMessage = "Adds are up!",
 } end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "CaptainKromcrush",
+
+    retaliation_cmd = "retaliation",
+    retaliation_name = "反击风暴警告",
+    retaliation_desc = "通报他的反击风暴技能",
+
+    adds_cmd = "adds",
+    adds_name = "增援警告",
+    adds_desc = "通报增援被召唤时",
+
+    fear_cmd = "fear",
+    fear_name = "恐惧警告",
+    fear_desc = "恐惧计时条",
+
+    fearTrigger = "afflicted by Intimidating Shout",
+    fearTrigger2 = "Intimidating Shout fail",
+    fearMessage = "被恐惧",
+    fearBar = "恐惧冷却",
+
+    retaliationUpTrigger = "Captain Kromcrush gains Retaliation",
+    retaliationUpMessage = "反击风暴！停止输出！",
+
+    retaliationDownTrigger = "Retaliation fades from Captain Kromcrush",
+    retaliationDownMessage = "反击风暴结束！上！",
+
+    retaliationHurtTrigger = "Captain Kromcrush's Retaliation hits you for",
+    retaliationHurtMessage = "我是个白痴，被反击风暴伤害到了",
+
+    addsTrigger = "Help me crush these punys",
+    addsUpMessage = "增援出现了！",
+} end)
 local timer = {
 	retaliation = 15,
 	fear = 11.4,

--- a/Raids/DireMaul/Gordok.lua
+++ b/Raids/DireMaul/Gordok.lua
@@ -16,6 +16,31 @@ module.zonename = {
 --      Locals 			    --
 ------------------------------
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    ms_cmd = "ms",
+    ms_name = "致死打击",
+    ms_desc = "当有人受到致死打击时进行警告",
+
+    stomp_cmd = "stomp",
+    stomp_name = "战争践踏",
+    stomp_desc = "当有人受到战争践踏时进行警告",
+
+    charge_cmd = "charge",
+    charge_name = "冲锋",
+    charge_desc = "当有人受到冲锋时进行警告",
+
+    -- AceConsole strings
+    cmd = "Gordok",
+
+    warStomp_bar = "战争践踏",
+    warStomp2_bar = "第二次战争践踏",
+    ms_bar = "致死打击",
+    charge_bar = "冲锋",
+
+} end )
 local timer = {
 	firstWarStomp = 7,
 	secondWarStomp = {27,38},

--- a/Raids/EmeraldSanctum/Erennius.lua
+++ b/Raids/EmeraldSanctum/Erennius.lua
@@ -38,6 +38,41 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_someYell = "Your efforts...",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Erennius",
+
+    wailoferennius_cmd = "wailoferennius",
+    wailoferennius_name = "埃伦纽斯之嚎警报",
+    wailoferennius_desc = "埃伦纽斯之嚎出现时进行警告",
+
+    howloferennius_cmd = "howloferennius",
+    howloferennius_name = "埃伦纽斯之吼警报",
+    howloferennius_desc = "埃伦纽斯之吼出现时进行警告",
+    
+    volley_cmd = "volley",
+    volley_name = "毒箭齐射警报",
+    volley_desc = "毒箭齐射出现时进行警告",
+    
+    --Erennius vv
+    trigger_wailOfErenniusCast = "埃伦纽斯开始施放",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_wailOfErenniusCast = "正在施放群体睡眠",
+    bar_wailOfErenniusAfflicted = "群体睡眠",
+    bar_wailOfErenniusCd = "群体睡眠冷却",
+    
+    trigger_howlOfErennius = "受到了埃伦纽斯之嚎效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_howlOfErenniusResist = "Howl of Erennius was resisted",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+    bar_howlOfErenniusCD = "沉默冷却",
+    bar_howlOfErenniusAfflicted = "沉默！",
+    
+    trigger_volley = "受到了毒箭之雨效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_volley = "毒箭齐射",
+    --Erennius ^^
+    
+    trigger_someYell = "Your efforts...",
+} end )
 local timer = {
 	wailOfErenniusCast = 6,
 	wailOfErenniusAfflicted = 3,

--- a/Raids/EmeraldSanctum/SanctumDragonkin.lua
+++ b/Raids/EmeraldSanctum/SanctumDragonkin.lua
@@ -33,6 +33,24 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SanctumDragonkin",
+
+    reflect_cmd = "reflect",
+    reflect_name = "反射警报",
+    reflect_desc = "圣所龙人获得反射时进行警告",
+
+    trigger_reflect = "圣所龙人获得了反射的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_reflectFade = "反射效果从圣所龙人身上消失。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+        
+    bar_reflect = "龙人法术反射",
+    msg_reflect = "龙人法术反射",
+    
+    ["You have slain %s!"] = "你已经击败了%s！",
+} end )
 local timer = {
 	reflect = 5,
 }

--- a/Raids/EmeraldSanctum/SanctumDreamer.lua
+++ b/Raids/EmeraldSanctum/SanctumDreamer.lua
@@ -32,6 +32,26 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SanctumDreamer",
+
+    dreamstate_cmd = "dreamstate",
+    dreamstate_name = "梦境状态警报",
+    dreamstate_desc = "梦境状态出现时进行警告",
+
+    trigger_sleepYou = "你受到了梦境效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_sleepFade = "梦境效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY
+    trigger_sleepOther = "(.+)受到了梦境效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    
+    --bar_dreamstate = " is Sleeping",
+    bar_dreamstate = "治疗沉睡队友！",
+    
+    ["You have slain %s!"] = "你已击败了%s！",
+    you = "你",
+} end )
 local timer = {
 	dreamstate = 10,
 }

--- a/Raids/EmeraldSanctum/SanctumSupressor.lua
+++ b/Raids/EmeraldSanctum/SanctumSupressor.lua
@@ -31,6 +31,25 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SanctumSupressor",
+
+    emeraldsupression_cmd = "emeraldsupression",
+    emeraldsupression_name = "翡翠镇压警报",
+    emeraldsupression_desc = "翡翠镇压出现时进行警告",
+    
+    trigger_emeraldSupressionYou = "你受到了翡翠镇压效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_emeraldSupressionOther = "(.+)受到了翡翠镇压效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    trigger_emeraldSupressionFade = "翡翠镇压效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY
+    
+    bar_emeraldSupression = " 被镇压（驱散魔法）！！",
+    
+    ["You have slain %s!"] = "你已击败了%s！",
+    you = "你",
+} end )
 local timer = {
 	emeraldSupression = 12,
 }

--- a/Raids/EmeraldSanctum/SanctumWyrm.lua
+++ b/Raids/EmeraldSanctum/SanctumWyrm.lua
@@ -31,6 +31,25 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SanctumWyrm",
+
+    volley_cmd = "volley",
+    volley_name = "毒箭齐射警报",
+    volley_desc = "毒箭齐射出现时进行警告",
+
+    trigger_volley = "圣所巨龙的毒箭之雨",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_volley = "毒箭齐射（清毒）",
+    
+    trigger_volleyYou = "圣所巨龙的毒箭之雨击中你造成",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_volley = "保持最远距离以躲避毒箭齐射！",
+    
+    ["You have slain %s!"] = "你已击败了%s！",
+	
+} end )
 local timer = {
 	volley = 15,
 }

--- a/Raids/EmeraldSanctum/SanctumWyrmkin.lua
+++ b/Raids/EmeraldSanctum/SanctumWyrmkin.lua
@@ -31,6 +31,25 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SanctumWyrmkin",
+
+    wyrmkinsvenom_cmd = "wyrmkinsvenom",
+    wyrmkinsvenom_name = "龙族毒液警报",
+    wyrmkinsvenom_desc = "龙族毒液出现时进行警告",
+
+    trigger_wyrmkinsVenomYou = "你受到了龙族毒液效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_wyrmkinsVenomFade = "龙族毒液效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY
+    trigger_wyrmkinsVenomOther = "(.+)受到了龙族毒液效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    
+    bar_wyrmkinsVenom = " 中了毒液（驱毒）！！！",
+    
+    ["You have slain %s!"] = "你已击败了%s！",
+    you = "你",
+} end )
 local timer = {
 	wyrmkinsVenom = 30,--tbd
 }

--- a/Raids/EmeraldSanctum/Solnius.lua
+++ b/Raids/EmeraldSanctum/Solnius.lua
@@ -73,6 +73,62 @@ L:RegisterTranslations("enUS", function() return {
 	--trigger_yellSmt = "The dream beckons us all, you shall remain here forever...",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Solnius",
+
+    transitions_cmd = "transitions",
+    transitions_name = "过渡阶段警报",
+    transitions_desc = "过渡阶段出现时进行警告",
+
+    --[[
+    wailoferennius_cmd = "wailoferennius",
+    wailoferennius_name = "埃伦纽斯之嚎警报",
+    wailoferennius_desc = "埃伦纽斯之嚎出现时进行警告",
+
+    howloferennius_cmd = "howloferennius",
+    howloferennius_name = "埃伦纽斯之吼警报",
+    howloferennius_desc = "埃伦纽斯之吼出现时进行警告",
+    
+    volley_cmd = "volley",
+    volley_name = "毒箭齐射警报",
+    volley_desc = "毒箭齐射出现时进行警告",
+    ]]--
+
+    bar_isImmune = "索尔纽斯免疫",
+    msg_isImmune = "索尔纽斯免疫",
+    
+    trigger_solniusSleep = "索尔纽斯获得了Sleep Visual DND的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_solniusSleepFade = "Sleep Visual DND效果从索尔纽斯身上消失。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_isSleeping = "索尔纽斯正在沉睡",
+    msg_isSleeping = "小怪来袭！45秒内击杀",
+    msg_isSleepingFade = "索尔纽斯醒来了！",
+
+    --[[Erennius vv
+    trigger_wailOfErenniusCast = "Erennius begins to cast Wail of Erennius.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_wailOfErenniusCast = "正在施放埃伦纽斯之嚎",
+    bar_wailOfErenniusAfflicted = "埃伦纽斯之嚎效果",
+    bar_wailOfErenniusCd = "埃伦纽斯之嚎冷却",
+    
+    trigger_howlOfErennius = "afflicted by Howl of Erennius",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_howlOfErenniusResist = "Howl of Erennius was resisted",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+    bar_howlOfErenniusCD = "沉默冷却",
+    bar_howlOfErenniusAfflicted = "被沉默！",
+    
+    trigger_volley = "afflicted by Poison Bolt Volley",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_volley = "毒箭齐射",
+    --Erennius ^^--]]
+    
+    trigger_engage = "You think you can interfere with my eternal duty? The awakening has been fortold long before your kind has existed mortals, you shall regret setting foot on our hallowed ground!",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_hardMode = "You will not disturb the Awakener...",--CHAT_MSG_MONSTER_YELL
+    msg_hardModeOn = "埃伦纽斯加入战斗；困难模式开启 - 祝你好运！",
+    msg_hardModeOff = "埃伦纽斯在索尔纽斯之前死亡；困难模式取消 - *胆小鬼*",
+    
+    --trigger_yellSmt = "The dream beckons us all, you shall remain here forever...",
+} end )
 local timer = {
 	isImmune = 600,
 	isSleeping = 45,

--- a/Raids/Karazhan/BroodQueenAraxxna.lua
+++ b/Raids/Karazhan/BroodQueenAraxxna.lua
@@ -41,6 +41,41 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_engage = "What goes there, new prey to be entangled?",--CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "BroodQueenAraxxna",
+
+	volley_cmd = "volley",
+	volley_name = "巢毒齐射警报",
+	volley_desc = "巢毒齐射出现时进行警告",
+
+	leechingbite_cmd = "leechingbite",
+	leechingbite_name = "水蛭叮咬警报",
+	leechingbite_desc = "水蛭叮咬出现时进行警告",
+	
+	egg_cmd = "egg",
+	egg_name = "产卵警报",
+	egg_desc = "产卵时进行警告",
+	
+	
+	
+	trigger_volley = "Brood Queen Araxxna's Brood Venom Volley hits",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	bar_volley = "巢毒齐射",
+	
+	trigger_leechingBiteYou = "You are afflicted by Leeching Bite.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_leechingBiteOther = "(.+) is afflicted by Leeching Bite.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_leechingBiteFade = "Leeching Bite fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	bar_leechingBite = " 水蛭叮咬",
+
+	trigger_eggSpawn = "My minions shall consume you!",--CHAT_MSG_MONSTER_YELL
+	bar_eggHatch = "掠网蛛卵孵化",
+	msg_eggSpawn = "2个卵即将孵化！",
+	
+	trigger_engage = "What goes there, new prey to be entangled?",--CHAT_MSG_MONSTER_YELL
+	you = "you",
+} end )
 local timer = {
 	volley = 8,
 	leechingBite = 10,

--- a/Raids/Karazhan/ClawlordHowlfang.lua
+++ b/Raids/Karazhan/ClawlordHowlfang.lua
@@ -39,6 +39,38 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_engage = "So it was you I smelled! Such a foul taint.",--CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "ClawlordHowlfang",
+
+    terrifyingpresence_cmd = "terrifyingpresence",
+    terrifyingpresence_name = "恐怖气场警报",
+    terrifyingpresence_desc = "恐怖气场出现时进行警告",
+
+    curse_cmd = "curse",
+    curse_name = "诅咒警报",
+    curse_desc = "诅咒出现时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+
+
+    trigger_terrifyingPresenceSelf = "You are afflicted by Terrifying Presence %((.+)%).",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    --trigger_terrifyingPresence = "(.+) is afflicted by Terrifying Presence %((.+)%).",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_terrifyingPresence = "% 减益效果",
+    
+    trigger_curse = "afflicted by Shadowbane Curse.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_curse = "影刃诅咒，快驱散！",
+    
+    trigger_yellEnrage = "My pack shall tear you apart, bone by bone!",--CHAT_MSG_MONSTER_YELL
+    msg_enrage = "激怒！",
+    
+    trigger_engage = "So it was you I smelled! Such a foul taint.",--CHAT_MSG_MONSTER_YELL
+} end )
 local timer = {
 	terrifyingPresence = 10,
 }

--- a/Raids/Karazhan/DarkRiderChampion.lua
+++ b/Raids/Karazhan/DarkRiderChampion.lua
@@ -29,6 +29,23 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "darkriderchampion",
+
+    reaverstorm_cmd = "reaverstorm",
+    reaverstorm_name = "掠夺者风暴警报",
+    reaverstorm_desc = "掠夺者风暴施放时进行警告",
+
+
+    trigger_reaverstorm = "Dark Rider Champion begins to perform Reaver Storm.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_reaverstormCd = "掠夺者风暴冷却",
+    bar_reaverstormCast = "掠夺者风暴施放",
+
+    ["You have slain %s!"] = "你杀死了%s！",
+} end )
 local timer = {
 	reaverstormCd = 5.5,
 	reaverstormCast = 1.5,

--- a/Raids/Karazhan/Grizikil.lua
+++ b/Raids/Karazhan/Grizikil.lua
@@ -37,6 +37,36 @@ L:RegisterTranslations("enUS", function() return {
 	msg_pullAll = "Pull --ALL-- imp packs before engaging Grizikil!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Grizikil",
+
+    rainoffire_cmd = "rainoffire",
+    rainoffire_name = "火焰之雨警报",
+    rainoffire_desc = "火焰之雨出现时进行警告",
+
+    flamewave_cmd = "flamewave",
+    flamewave_name = "烈焰波警报",
+    flamewave_desc = "烈焰波出现时进行警告",
+    
+
+    
+    trigger_rainOfFireYou = "You suffer (.+) Fire damage from Grizikil's Grellkin Rain of Fire.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_rainOfFireYou = "离开火焰之雨区域！",
+    
+    trigger_flamewave = "Grizikil is afflicted by Flamewave.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    trigger_flamewaveFade = "Flamewave fades from Grizikil.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_flamewave = "烈焰波",
+    msg_flamewave = "烈焰波，近战快躲开！",
+    
+    trigger_yellSmt = "You-you-you no defeat me, I am strong!",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_engage = "Whats this? You're here for the orb?! ITS MINE, Grellkin, get them!",--CHAT_MSG_MONSTER_YELL
+    
+    msg_pullAll = "在与格里兹基尔交战前，拉清--所有--小鬼群！",
+} end )
 local timer = {
 	flamewave = 9,
 }

--- a/Raids/Karazhan/LordBlackwaldII.lua
+++ b/Raids/Karazhan/LordBlackwaldII.lua
@@ -50,6 +50,51 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_engage = "You dare disturb the Dark Rider Lord?",--CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "LordBlackwaldII",
+
+    reaverstorm_cmd = "reaverstorm",
+    reaverstorm_name = "掠夺者风暴警报",
+    reaverstorm_desc = "掠夺者风暴出现时进行警告",
+
+    boon_cmd = "boon",
+    boon_name = "布莱克沃尔兹的恩赐警报",
+    boon_desc = "布莱克沃尔兹的恩赐出现时进行警告",
+    
+    empoweredsoul_cmd = "empoweredsoul",
+    empoweredsoul_name = "强化灵魂警报",
+    empoweredsoul_desc = "强化灵魂出现时进行警告",
+    
+    summon_cmd = "summon",
+    summon_name = "召唤警报",
+    summon_desc = "召唤出现时进行警告",
+    
+
+    
+    trigger_reaverstorm = "Lord Blackwald II begins to perform Reaver Storm.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_reaverstormCd = "掠夺者风暴冷却",
+    bar_reaverstormCast = "掠夺者风暴施放",
+    
+    trigger_boonYou = "You are afflicted by Blackwalds Boon.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_boonOther = "(.+) is afflicted by Blackwalds Boon.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_boonFade = "Blackwalds Boon fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_boon = "恩赐 ",
+    
+    trigger_empoweredSoulYou = "You are afflicted by Empowered Soul.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_empoweredSoulOther = "(.+) is afflicted by Empowered Soul.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_empoweredSoul = " 强化灵魂",
+    
+    trigger_yellSummon = "I call upon the Scythe of Elune, grant me your power!",--CHAT_MSG_MONSTER_YELL
+    bar_summon = "召唤小怪",
+    msg_yellSummon = "影刃怒牙已被召唤！",
+    
+    trigger_engage = "You dare disturb the Dark Rider Lord?",--CHAT_MSG_MONSTER_YELL
+    clickme = " >点击我！<",
+    you = "you",
+} end )
 local timer = {
 	reaverstormCd = 5.5,
 	reaverstormCast = 1.5,

--- a/Raids/Karazhan/Moroes.lua
+++ b/Raids/Karazhan/Moroes.lua
@@ -68,6 +68,67 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_yellSmt = "Most impressive, it would appear your skills do match your bravery.",-- CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Moroes",
+
+    smokebomb_cmd = "smokebomb",
+    smokebomb_name = "烟雾弹警报",
+    smokebomb_desc = "烟雾弹出现时进行警告",
+
+    reflect_cmd = "reflect",
+    reflect_name = "法术反射警报",
+    reflect_desc = "法术反射出现时进行警告",
+    
+    shufflekick_cmd = "shufflekick",
+    shufflekick_name = "乱踢警报",
+    shufflekick_desc = "乱踢出现时进行警告",
+    
+    curse_cmd = "curse",
+    curse_name = "诅咒警报",
+    curse_desc = "诅咒出现时进行警告",
+    
+    dust_cmd = "dust",
+    dust_name = "闪光尘警报",
+    dust_desc = "闪光尘出现时进行警告",
+    
+
+
+    trigger_p1 = "New guests? It has been a while since we have had those. I assume your arrival has taken -some- effort even if you were uninvited!",--CHAT_MSG_MONSTER_YELL
+    bar_p1 = "莫罗斯阶段1",
+    
+    trigger_p1End = "Now now, why don't we save such pleasantries for a more, entertaining show. Meet me at the stage, and we shall truly decide the outcome of our engagement.",--CHAT_MSG_MONSTER_YELL
+    trigger_p2 = "It is my duty to protect and watch over this tower, as approved by my master. I shall make sure to endulge in your little spectacle. Why don't we put on a show for those in attendance, hmm? Legalbrow, if you would please, play my theme.",--CHAT_MSG_MONSTER_YELL
+    bar_p2 = "莫罗斯阶段2",
+    
+    trigger_smokeBombYou = "You are afflicted by Smoke Bomb.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_smokeBombOther = "(.+) is afflicted by Smoke Bomb.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    trigger_smokeBombFade = "Smoke Bomb fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_smokeBomb = "玩家中了烟雾弹",
+    
+    trigger_reflect = "Moroes gains Reflection.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_reflectFade = "Reflection fades from Moroes.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_reflect = "法术反射！",
+    msg_reflect = "法术反射！",
+    
+    trigger_shuffleKickYou = "You are afflicted by Shuffle Kick.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_shuffleKick = "(.+) is afflicted by Shuffle Kick.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    trigger_shuffleKickFade = "Shuffle Kick fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_shuffleKick = " 被踢",
+    
+    trigger_curse = "afflicted by Moroes Curse.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    msg_curse = "莫罗斯的诅咒，快驱散！",
+    
+    trigger_dustYou = "You are afflicted by Glittering Dust.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_dust = "(.+) is afflicted by Glittering Dust.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    trigger_dustFade = "Glittering Dust fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_dust = " 中了闪光尘",
+    
+    trigger_yellSmt = "Most impressive, it would appear your skills do match your bravery.",-- CHAT_MSG_MONSTER_YELL
+    you = "you",
+} end )
 local timer = {
 	p1 = 7,
 	p2 = 12,

--- a/Raids/Karazhan/PhantomServant.lua
+++ b/Raids/Karazhan/PhantomServant.lua
@@ -31,6 +31,26 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "phantomservant",
+
+    phantomscream_cmd = "phantomscream",
+    phantomscream_name = "幻影尖叫警报",
+    phantomscream_desc = "幻影尖叫出现时进行警告",
+
+    trigger_phantomScreamYou = "You are afflicted by Phantom Scream.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_phantomScreamOther = "(.+) is afflicted by Phantom Scream.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    --trigger_phantomScreamFade = "Phantom Scream fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+    bar_phantomScreamCd = "幻影尖叫冷却",
+    --bar_phantomScreamAfflicted = " Silenced",
+
+    ["You have slain %s!"] = "你杀死了%s！",
+    you = "you",
+} end )
 local timer = {
 	phantomScream = 10,
 }

--- a/Raids/MC/AncientCoreHound.lua
+++ b/Raids/MC/AncientCoreHound.lua
@@ -30,6 +30,40 @@ L:RegisterTranslations("enUS", function() return {
 	
 	msg_ancientHysteria = "Ancient Hysteria - Decurse!",
 } end )
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Corehound",
+
+    bars_cmd = "bars",
+    bars_name = "切换计时条",
+    bars_desc = "切换显示计时条的状态。",
+	
+	
+	trigger_debuff = "你受到了(.+)效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_debuffFail = ".*的(.+)施放失败。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_debuffResist = ".*的(.+)被.*抵抗了。", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_debuff = "Debuff",
+	
+    msg_ancientDread = "上古恐慌 - 驱散！",
+	
+    bar_ancientDespair = "迷惑",
+	
+    bar_groundStomp = "大地践踏",
+	
+    msg_cauterizingFlames = "灼烧之焰 - 驱散！",
+	
+    msg_witheringHeat = "枯萎热浪 - 驱散！",
+	
+    msg_ancientHysteria = "上古狂乱 - 解除诅咒！",
+    
+    s_ancientdread = "上古恐慌",
+    s_ancientdespair = "上古绝望",
+    s_groundstomp = "大地践踏",
+    s_cauterizingflames = "灼烧之焰",
+    s_witheringheat = "枯萎热浪",
+    s_ancienthysteria = "上古狂乱",
+} end )
 
 local timer = {
 	debuffFirst = 12,
@@ -86,22 +120,31 @@ function module:OnDisengage()
 
 end
 
+local function IsTrackedDebuff(name)
+	return name == L["s_ancientdread"]
+		or name == L["s_ancientdespair"]
+		or name == L["s_groundstomp"]
+		or name == L["s_cauterizingflames"]
+		or name == L["s_witheringheat"]
+		or name == L["s_ancienthysteria"]
+end
+
 function module:Event(msg)
 	if string.find(msg, L["trigger_debuff"]) then
 		local _,_, debuff, _ = string.find(msg, L["trigger_debuff"])
-		if debuff == "Ancient Dread" or "Ancient Despair" or "Ground Stomp" or "Cauterizing Flames" or "Withering Heat" or "Ancient Hysteria" then
+		if IsTrackedDebuff(debuff) then
 			self:Sync(syncName.debuff .. " " .. debuff)
 		end
 	
 	elseif string.find(msg, L["trigger_debuffFail"]) then
 		local _,_, debuff, _ = string.find(msg, L["trigger_debuffFail"])
-		if debuff == "Ancient Dread" or "Ancient Despair" or "Ground Stomp" or "Cauterizing Flames" or "Withering Heat" or "Ancient Hysteria" then
+		if IsTrackedDebuff(debuff) then
 			self:Sync(syncName.debuff .. " " .. debuff)
 		end
 	
 	elseif string.find(msg, L["trigger_debuffResist"]) then
 		local _,_, debuff, _ = string.find(msg, L["trigger_debuffResist"])
-		if debuff == "Ancient Dread" or "Ancient Despair" or "Ground Stomp" or "Cauterizing Flames" or "Withering Heat" or "Ancient Hysteria" then
+		if IsTrackedDebuff(debuff) then
 			self:Sync(syncName.debuff .. " " .. debuff)
 		end
 	end

--- a/Raids/MC/CoreHound.lua
+++ b/Raids/MC/CoreHound.lua
@@ -33,6 +33,23 @@ L:RegisterTranslations("enUS", function() return {
 
 	["You have slain %s!"] = true,
 } end )
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "CoreHound",
+
+	respawn_cmd = "respawn",
+    respawn_name = "重生警报",
+    respawn_desc = "重生出现时进行警告",
+	
+	
+	trigger_smolder = "熔火恶犬.*开始.*smolder",
+    bar_respawn = "重生",
+    msg_respawn = "在10秒内杀死所有熔火恶犬",
+
+    ["You have slain %s!"] = true,
+    ["You have slain %s!"] = "你击杀了 %s！",
+} end )
 
 local timer = {
 	respawn = 10,

--- a/Raids/MC/TwinGolems.lua
+++ b/Raids/MC/TwinGolems.lua
@@ -26,6 +26,21 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+L:RegisterTranslations("zhCN", function()
+	return {
+		cmd = "TwinGolems",
+
+		bulwark_cmd = "bulwark",
+		bulwark_name = "熔火壁垒警报",
+		bulwark_desc = "为熔火壁垒提供计时条和切换目标提示",
+
+		trigger_bulwarkGain = "(.+)获得了熔火壁垒的效果",
+		trigger_bulwarkFade = "熔火壁垒效果从(.+)身上消失。",
+		msg_switch = "切换攻击 %s",
+		bar_bulwark = "%s 壁垒",
+	}
+end)
+
 -- timer and icon variables
 local timer = {
 	bulwark = 15,

--- a/Raids/Naxxramas/Anubrekhan.lua
+++ b/Raids/Naxxramas/Anubrekhan.lua
@@ -56,6 +56,59 @@ L:RegisterTranslations("enUS", function() return {
 	bar_webDur = "Webbed!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Anubrekhan",
+
+    locust_cmd = "locust",
+    locust_name = "蝗虫群警报",
+    locust_desc = "蝗虫群出现时进行警告。",
+
+    impale_cmd = "impale",
+    impale_name = "穿刺警报",
+    impale_desc = "穿刺出现时进行警告。",
+
+    enrage_cmd = "enrage",
+    enrage_name = "地穴卫士激怒警报",
+    enrage_desc = "地穴卫士激怒时进行警告。",
+
+    web_cmd = "web",
+    web_name = "地穴卫士网警报",
+    web_desc = "地穴卫士放网时进行警告。",
+	
+	
+	trigger_engage1 = "一些小点心",
+	trigger_engage2 = "对，跑吧！那样伤口出血就更多了！",
+	trigger_engage3 = "你们逃不掉的。",
+	
+    trigger_locustSwarmCast = "阿努布雷坎开始施放虫群风暴。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_locustSwarmCasting = "正在施放虫群风暴！",
+    bar_locustSwarmCasting = "正在施放虫群风暴！",
+
+    trigger_locustSwarmGain = "阿努布雷坎受到了虫群风暴效果的影响。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_locustSwarmIsUp = "虫群风暴！",
+
+    trigger_locustSwarmEnds = "虫群风暴效果从阿努布雷坎身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_locustSwarmCd = "虫群风暴 CD",
+    bar_locustSwarmOffCd = "虫群风暴随时可能开始！",
+	
+    trigger_locustSwarmYou = "你受到了虫群风暴效果的影响", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_locustYou = "远离Boss！",
+    trigger_locustSwarmYouFade = "虫群风暴效果从你身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    
+    trigger_impale = "阿努布雷坎的穿刺击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_impale = "穿刺 CD",
+    
+    trigger_enrage = "地穴卫士变得愤怒了！", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "地穴卫士激怒 - 使用眩晕和陷阱！",
+    
+    trigger_web = "受到了蛛网效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_web2 = "蛛网效果从", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_webCd = "蛛网 CD",
+    bar_webDur = "被网住了！",
+} end )
 local timer = {
 	firstLocustSwarm = {80,120},--96
 	readyFirstLocustSwarm = 40,

--- a/Raids/Naxxramas/DeathknightCaptain.lua
+++ b/Raids/Naxxramas/DeathknightCaptain.lua
@@ -27,6 +27,26 @@ L:RegisterTranslations("enUS", function() return {
 	["You have slain %s!"] = true,
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "deathknightCaptain",
+	
+	whirlwind_cmd = "whirlwind",
+    whirlwind_name = "旋风斩警报",
+    whirlwind_desc = "旋风斩出现时进行警告",
+	
+	
+	trigger_whirlwind = "死亡骑士队长获得了旋风斩的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_whirlwindFade = "旋风斩效果从", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_whirlwind1 = "旋风斩 1",
+    bar_whirlwind2 = "旋风斩 2",
+    bar_whirlwindCd1 = "旋风斩 CD 1",
+    bar_whirlwindCd2 = "旋风斩 CD 2",
+
+    ["You have slain %s!"] = "你杀死了%s！",
+} end )
 local timer = {
 	whirlwindDur = 6,
 	whirlwindCd = 9,

--- a/Raids/Naxxramas/DeathknightCavalier.lua
+++ b/Raids/Naxxramas/DeathknightCavalier.lua
@@ -29,6 +29,25 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "DeathknightCavalier",
+
+    deathcoil_cmd = "deathcoil",
+    deathcoil_name = "死亡缠绕警报",
+    deathcoil_desc = "死亡缠绕出现时进行警告",
+    
+    
+    trigger_deathCoilYou = "你受到了死亡缠绕效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_deathCoilOther = "(.+)受到了死亡缠绕效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_deathCoilFade = "死亡缠绕效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_PARTY_OTHER // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_deathCoil = " 死亡缠绕",
+
+    ["You have slain %s!"] = "你杀死了%s！",
+    you = "你",
+} end )
 local timer = {
 	deathCoil = 3,
 }

--- a/Raids/Naxxramas/Faerlina.lua
+++ b/Raids/Naxxramas/Faerlina.lua
@@ -82,6 +82,86 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_dispel = "(.+) casts Dispel Magic on Naxxramas Worshipper.",--CHAT_MSG_SPELL_FRIENDLYPLAYER_BUFF
 	msg_dispelCast = " Dispelled a Worshipper! Don't Dispel MC!",
 } end )
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Faerlina",
+
+    silence_cmd = "silence",
+    silence_name = "沉默警报",
+    silence_desc = "沉默出现时进行警告",
+
+    bigicon_cmd = "bigicon",
+    bigicon_name = "心灵控制和激怒大图标警报",
+    bigicon_desc = "当牧师必须进行心灵控制和Boss进入激怒时显示大图标警报",
+
+    sounds_cmd = "sounds",
+    sounds_name = "心灵控制和激怒声音警报",
+    sounds_desc = "当牧师必须进行心灵控制和Boss进入激怒时发出声音警报",
+    
+    mc_cmd = "mc",
+    mc_name = "心灵控制计时条",
+    mc_desc = "信徒心灵控制的计时条",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+
+    rain_cmd = "rain",
+    rain_name = "火焰之雨警报",
+    rain_desc = "当你站在火焰之雨中时进行警告",
+    
+    raidSilence_cmd = "raidSilence",
+    raidSilence_name = "团队成员沉默警报",
+    raidSilence_desc = "当团队成员被沉默时进行警告",
+
+    poison_cmd = "poison",
+    poison_name = "毒箭之雨警报",
+    poison_desc = "对萨满进行毒箭之雨的警告",
+    
+	trigger_start1 = "跪下求饶吧，懦夫！",
+	trigger_start2 = "以主人之名杀掉他们！",
+	trigger_start3 = "休想从我面前逃掉！",
+	trigger_start4 = "逃啊！有本事就逃啊！",
+
+    trigger_rain = "你受到了火焰之雨效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE --string find cause could be a partial absorb
+    
+    trigger_poison = "受到了毒箭之雨效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    
+    trigger_raidSilence = "受到了沉默效果的影响。",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_raidSilence = "团队成员沉默",
+    
+    trigger_mcGain = "(.+)受到了精神控制效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_BUFFS // CHAT_MSG_SPELL_PERIODIC_PARTY_BUFFS
+    trigger_mcGainYou = "你获得了精神控制的效果。",--CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS
+    --trigger_mcGain = "Naxxramas Worshipper is afflicted by Mind Control",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    mc_bar = "精神控制",
+    
+    trigger_worshipperDies = "纳克萨玛斯信奉者死亡了。",--CHAT_MSG_COMBAT_FRIENDLY_DEATH
+
+    trigger_mcFade = "精神控制效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    --trigger_mcFade = "Naxxramas Worshipper begins to perform Widow's Embrace",--CHAT_MSG_SPELL_FRIENDLYPLAYER_BUFF
+    --trigger_mcSuccess = "Widow's Embrace fades from Naxxramas Worshipper.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    --trigger_embrace = "Grand Widow Faerlina gains Widow's Embrace.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_silencedHalf = "在激怒前沉默！下一个沉默在30秒后",
+    msg_silenceZero = "过早沉默！激怒无延迟",
+    bar_silence = "Boss沉默",
+    
+    trigger_enrage = "黑女巫法琳娜获得了激怒的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrageGain = "激怒！",
+    bar_enrageGain = "Boss激怒！",
+    
+    trigger_enrageFade = "激怒效果从黑女巫法琳娜身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_silencedEnrageFull = "激怒被沉默！下一个激怒在61秒后",
+    
+    msg_enrageSoon = "激怒将在10秒后到来",
+    
+    bar_enrageCD = "激怒冷却",
+    
+    trigger_dispel = "(.+) casts Dispel Magic on Naxxramas Worshipper.",--CHAT_MSG_SPELL_FRIENDLYPLAYER_BUFF
+    msg_dispelCast = "驱散了一个信徒！请勿驱散心灵控制！",
+    you = "你",
+} end )
 local timer = {
 	silencedEnrage = 61,
 	silencedWithoutEnrage = 30,

--- a/Raids/Naxxramas/Gargoyle.lua
+++ b/Raids/Naxxramas/Gargoyle.lua
@@ -39,6 +39,19 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Stoneskin",
+
+    stoneskin_cmd = "stoneskin",
+    stoneskin_name = "石肤术警报",
+    stoneskin_desc = "石肤术出现时进行警告",
+
+    stoneskintrigger = "%s发出奇怪的声音。",
+    stoneskinwarn = "正在施放石肤术！",
+} end )
 local timer = {
 	stoneskin = 6,
 }

--- a/Raids/Naxxramas/Gluth.lua
+++ b/Raids/Naxxramas/Gluth.lua
@@ -68,6 +68,64 @@ L:RegisterTranslations("enUS", function() return {
 	bar_wound = " Wounds",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Gluth",
+
+	fear_cmd = "fear",
+    fear_name = "恐惧警报",
+    fear_desc = "恐惧出现时进行警告",
+
+    frenzy_cmd = "frenzy",
+    frenzy_name = "疯狂警报",
+    frenzy_desc = "疯狂出现时进行警告",
+
+    enrage_cmd = "enrage",
+    enrage_name = "狂暴计时器",
+    enrage_desc = "狂暴出现时进行警告",
+
+    decimate_cmd = "decimate",
+    decimate_name = "屠杀警报",
+    decimate_desc = "屠杀出现时进行警告",
+    
+    zombies_cmd = "zombies",
+    zombies_name = "僵尸刷新",
+    zombies_desc = "显示僵尸刷新计时器",
+    
+    wound_cmd = "wound",
+    wound_name = "重伤警报",
+    wound_desc = "重伤出现时进行警告",
+	
+	
+	trigger_frenzyGain = "格拉斯获得了疯狂的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_frenzyFade = "疯狂效果从格拉斯身上消失。",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_frenzy = "疯狂 - 使用宁神射击！",
+    bar_frenzyGain = "疯狂 - 宁神射击！",
+    bar_frenzyCD = "疯狂 CD",
+	
+	trigger_enrage = "格拉斯获得了狂暴的效果。",--to be confirmed
+    msg_enrage60 = "60秒后狂暴",
+    msg_enrage10 = "10秒后狂暴",
+    msg_enrage = "狂暴！",
+    bar_enrage = "狂暴",
+		
+	trigger_decimate = "残杀击中",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_decimate = "残杀！",
+    msg_decimate5 = "5秒后残杀",
+    bar_decimate = "残杀",
+	
+    bar_zombies = "下一个僵尸 - %d",
+		
+	trigger_fear = "恐惧怒吼效果的影响",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_fearCD = "恐惧 CD",
+    msg_fear = "恐惧！",
+	
+	trigger_woundYou = "你受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_woundOther = "(.+)受到了重伤效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_wound = " 重伤",
+} end )
 local timer = {
 	decimate = 105,
 	zombie = 6,

--- a/Raids/Naxxramas/Gothik.lua
+++ b/Raids/Naxxramas/Gothik.lua
@@ -59,6 +59,54 @@ L:RegisterTranslations("enUS", function() return {
 	msg_gateOpen = "The Central gate opens!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Gothik",
+
+    room_cmd = "room",
+    room_name = "房间到达警报",
+    room_desc = "戈提克传送到房间时进行警告",
+
+    add_cmd = "add",
+    add_name = "小怪刷新警报",
+    add_desc = "小怪刷新时进行警告",
+
+    adddeath_cmd = "adddeath",
+    adddeath_name = "小怪死亡警报",
+    adddeath_desc = "小怪死亡时进行警告",
+
+
+    trigger_engage = "你公然无视超出你理解范围的力量",
+    trigger_bossDead = "完蛋了！",
+    
+    name_trainee = "无情的训练师",
+    name_traineeSpectral = "鬼灵训练师",
+    bar_trainee = "训练师 - ",
+    msg_traineeSoon = "3秒后出现11个训练师",
+    
+    name_deathKnight = "无情的死亡骑士",
+    name_deathKnightSpectral = "鬼灵死亡骑士",
+    bar_dk = "死亡骑士 - ",
+    msg_dkSoon = "3秒后出现7个死亡骑士",
+    msg_dkDead = "死亡骑士已死！",
+    
+    name_rider = "无情的骑兵",
+    name_riderSpectral = "鬼灵骑兵",
+    bar_rider = "骑兵 - ",
+    msg_riderSoon = "3秒后出现4个骑兵",
+    msg_riderDead = "骑兵已死！",
+    
+    trigger_inRoom = "我已经等够久了",
+    bar_inRoom = "进入房间",
+    msg_inRoom = "收割者戈提克传送到战场中！",
+    msg_inRoom10 = "10秒后戈提克即将到来",
+    
+    msg_gateOpen = "中央大门打开！",
+    c_unrelentingrider = "无情的骑兵",
+    c_unrelentingdeathknight = "无情的死亡骑士",
+} end )
 local timer = {
 	inroom = 274, --4:34
 	

--- a/Raids/Naxxramas/Grobbulus.lua
+++ b/Raids/Naxxramas/Grobbulus.lua
@@ -55,6 +55,56 @@ L:RegisterTranslations("enUS", function() return {
 	msg_lowHp = "Grobbulus <30% - Injecting more Often",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Grobbulus",
+
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+	
+	slimespray_cmd = "slimespray",
+    slimespray_name = "软泥喷射",
+    slimespray_desc = "显示软泥喷射的计时条",
+	
+	inject_cmd = "inject",
+    inject_name = "变异注射警报",
+    inject_desc = "当有人被注射时进行警告",
+
+    icon_cmd = "icon",
+    icon_name = "标记图标",
+    icon_desc = "在被注射的人员身上放置一个骷髅图标。(需要是助理或更高权限)",
+
+    cloud_cmd = "cloud",
+    cloud_name = "毒云",
+    cloud_desc = "毒云出现时进行警告",
+		
+		
+	trigger_enrage = "格罗布鲁斯陷入狂暴状态！",--to be confirmed
+    bar_enrage = "激怒",
+    msg_enrage60 = "1分钟后激怒",
+    msg_enrage10 = "10秒后激怒",
+    msg_enrage = "激怒！",
+	
+	trigger_slimeSpray = "软泥喷射",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_slimeSprayCD = "软泥喷射冷却",
+	
+	trigger_injectYou = "你受到了变异注射效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_injectOther = "(.+)受到了变异注射效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_injectFade = "变异注射效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_injected = " 注射",
+    msg_inject = " 注射",
+	
+	trigger_cloudCast = "格罗布鲁斯施放了毒性云雾。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_cloudCD = "毒云冷却",
+    msg_cloudCast = "毒云 -- 移动格罗布鲁斯！",
+	trigger_cloudHitsYou = "瘟疫毒云的中毒击中你",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	
+    msg_lowHp = "格罗布鲁斯生命值低于30% - 更频繁注射",
+	you = "你",
+} end )
 local timer = {
 	enrage = 720,
 	firstSlimeSpray = {20, 30},--25

--- a/Raids/Naxxramas/Heigan.lua
+++ b/Raids/Naxxramas/Heigan.lua
@@ -61,6 +61,57 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Heigan",
+
+    disease_cmd = "disease",
+    disease_name = "衰弱瘟疫警报",
+    disease_desc = "衰弱瘟疫出现时进行警告",
+    
+    manaBurn_cmd = "manaBurn",
+    manaBurn_name = "法力燃烧警报",
+    manaBurn_desc = "法力燃烧出现时进行警告",
+    
+    teleport_cmd = "teleport",
+    teleport_name = "传送警报",
+    teleport_desc = "传送出现时进行警告",
+
+    erruption_cmd = "erruption",
+    erruption_name = "爆发警报",
+    erruption_desc = "爆发出现时进行警告",
+
+    trigger_engage1 = "你现在是我的了！",--CHAT_MSG_MONSTER_YELL
+    trigger_engage2 = "你是下一个！",--CHAT_MSG_MONSTER_YELL
+    trigger_engage3 = "我看见你！",--CHAT_MSG_MONSTER_YELL
+    
+    trigger_die = "takes his last breath.",--to be confirmed
+    
+    trigger_disease = "受到了衰弱瘟疫效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_disease = "衰弱瘟疫冷却",
+    msg_disease = "衰弱瘟疫",
+    
+    trigger_manaBurn = "肮脏的希尔盖的法力燃烧",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_manaBurn = "法力燃烧冷却",
+    
+    trigger_manaBurnYou = "肮脏的希尔盖的法力燃烧击中你",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_manaBurnYou = "法力燃烧命中你！",
+
+    trigger_danceStart = "末日就在你身上。",--CHAT_MSG_MONSTER_YELL
+    msg_danceStart = "传送！",
+    bar_dancing = "跳舞结束",
+    bar_dancingSoon = "即将跳舞",
+    
+    msg_fightStart = "战斗开始！",
+    bar_fighting = "开始跳舞",
+    
+    bar_erruption = "爆发",	
+
+    ["Eye Stalk"] = "眼柄",
+    ["Rotting Maggot"] = "腐烂的蛆虫",
+} end )
 local timer = {
 	firstDiseaseCD = 30,
 	firstDiseaseAfterDanceCD = 5,

--- a/Raids/Naxxramas/Horsemen.lua
+++ b/Raids/Naxxramas/Horsemen.lua
@@ -117,6 +117,89 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+
+    cmd = "Horsemen",
+
+    mark_cmd = "mark",
+    mark_name = "印记警报",
+    mark_desc = "印记出现时进行警告",
+    
+    meteor_cmd = "meteor",
+    meteor_name = "流星警报",
+    meteor_desc = "库尔塔兹领主施放流星时进行警告。",
+    
+    wrath_cmd = "wrath",
+    wrath_name = "神圣之怒警报",
+    wrath_desc = "瑟里耶克爵士施放神圣之怒时进行警告。",
+    
+    void_cmd = "void",
+    void_name = "虚空领域警报",
+    void_desc = "女公爵布劳缪克丝施放虚空领域时进行警告。",
+    
+    shieldwall_cmd = "shieldwall",
+    shieldwall_name = "盾墙警报",
+    shieldwall_desc = "盾墙出现时进行警告",
+    
+    taunt_cmd = "taunt",
+    taunt_name = "嘲讽抵抗/成功警报",
+    taunt_desc = "嘲讽抵抗和嘲讽成功时进行警告",
+    
+    tankswarn_cmd = "tankswarn",
+    tankswarn_name = "嘲讽抵抗警报",
+    tankswarn_desc = "嘲讽抵抗时进行警告",
+	
+	
+    bar_markCount = "印记 ",
+    msg_markCount = "印记 ",
+    trigger_markZeliek = "受到了瑟里耶克印记效果的影响",
+    trigger_markKorthAzz = "受到了库尔塔兹印记效果的影响",
+    trigger_markBlaumeux = "受到了布劳缪克丝印记效果的影响",
+    trigger_markMograine = "受到了莫格莱尼印记效果的影响",
+    
+    trigger_markZeliekFade = "Mark of Zeliek fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    trigger_markKorthAzzFade = "Mark of Korth'azz fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    trigger_markBlaumeuxFade = "Mark of Blaumeux fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    trigger_markMograineFade = "Mark of Mograine fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_zeliekTankReady = "准备好对瑟里耶克爵士进行坦克",
+    msg_korthAzzTankReady = "准备好对库尔塔兹领主进行坦克",
+    msg_blaumeuxTankReady = "准备好对女公爵布劳缪克丝进行坦克",
+    msg_mograineTankReady = "准备好对大领主莫格莱尼进行坦克",
+    
+    trigger_markYou = "你受到了(.+)印记效果的影响",
+    msg_doubleMark = "你被超过一个印记命中 - 注意位置！",
+    
+    trigger_mark4 = "你受到了(.+)印记效果的影响%（4%）",
+    msg_mark4 = "你身上有4层印记 - 快跑开/吃暗抗！",
+    msg_mark4Tank = "身上有4层印记 - 替换我！",
+	
+    --trigger_void = "Lady Blaumeux casts Void Zone"
+    trigger_void2 = "你的命就是我的了！",
+    bar_void = "虚空领域",
+    msg_voidYou = "虚空领域在你身上！",
+    
+    --trigger_meteor = "Thane Korth'azz's Meteor hits ",
+    trigger_meteor2 = "我喜欢我的肉特别脆",
+    bar_meteor = "流星 CD",
+
+    --trigger_wrath = "Sir Zeliek's Holy Wrath hits ",
+    trigger_wrath2 = "我别无选择，只能服从！",
+    bar_wrath = "神圣之怒 CD",
+    
+    trigger_shieldWall = "(.*)获得了盾墙的效果。",
+    bar_shieldWall = " - 盾墙",
+    msg_shieldWallUp = " - 盾墙持续20秒",
+    msg_shieldWallFade = " - 盾墙结束！",
+    
+    trigger_tauntResist = "你的嘲讽被(.+)抵抗了。", --CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_growlResist = "你的低吼被(.+)抵抗了。", --CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_tauntResist = "嘲讽被抵抗",
+    
+    trigger_tauntSuccess = "你对(.+)使用嘲讽。", --CHAT_MSG_SPELL_SELF_DAMAGE
+    trigger_growlSuccess = "你对(.+)使用低吼。", --CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_tauntSuccess = "嘲讽成功",
+} end )
 local timer = {
 	firstMark = 20,
 	mark = 12,

--- a/Raids/Naxxramas/Kelthuzad.lua
+++ b/Raids/Naxxramas/Kelthuzad.lua
@@ -217,6 +217,164 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Kelthuzad",
+
+	phase_cmd = "phase",
+    phase_name = "阶段警报",
+    phase_desc = "阶段变化时进行警告。",
+	
+	p1adds_cmd = "p1adds",
+    p1adds_name = "第一阶段增援警报",
+    p1adds_desc = "第一阶段增援出现时进行提醒。",
+	
+	mc_cmd = "mc",
+    mc_name = "精神控制警报",
+    mc_desc = "精神控制发生时进行警告。",
+
+	--mcicon_cmd = "mcicon",
+    mcicon_name = "精神控制标记",
+    mcicon_desc = "在被精神控制的目标上标记团队标记。",
+
+	fissure_cmd = "fissure",
+    fissure_name = "红圈警报",
+    fissure_desc = "红圈出现时进行警告。",
+
+	frostblast_cmd = "frostblast",
+    frostblast_name = "冰墓警报",
+    frostblast_desc = "冰墓施放时进行警告。",
+	
+	frostblastframe_cmd = "frostblastframe",
+    frostblastframe_name = "冰墓目标框架",
+    frostblastframe_desc = "显示一个包含冰墓目标及其血量条的框架。",
+	
+	detonate_cmd = "detonate",
+    detonate_name = "法力爆炸警报",
+    detonate_desc = "法力爆炸施放时进行警告。",
+
+	detonateicon_cmd = "detonateicon",
+    detonateicon_name = "法力爆炸标记",
+    detonateicon_desc = "在法力爆炸的目标上标记团队标记。",
+	
+	frostbolt_cmd = "frostbolt",
+    frostbolt_name = "单体冰霜箭警报",
+    frostbolt_desc = "单体冰霜箭施放时进行警告。",
+
+	volley_cmd = "volley",
+    volley_name = "群体寒冰箭警报",
+    volley_desc = "群体寒冰箭施放时进行警告。",
+
+	guardian_cmd = "guardian",
+    guardian_name = "小强出现警报",
+    guardian_desc = "第三阶段小强出现时进行警告。",
+
+	shackle_cmd = "shackle",
+    shackle_name = "束缚亡灵计数",
+    shackle_desc = "统计对小强施放的束缚亡灵次数。",
+	
+	bloodtap_cmd = "bloodtap",
+    bloodtap_name = "血液分流计数",
+    bloodtap_desc = "统计小强身上的血液分流增益次数。",
+
+	proximity_cmd = "proximity",
+    proximity_name = "近距离警告",
+    proximity_desc = "显示近距离警告框架",
+	
+	
+	--Mortal Wound from Unstoppable Abomination, stacking, -10% healing, 15sec
+	
+	trigger_engage = "冰冷黑暗的爪牙、仆人、士兵，听从克尔苏加德的召唤！", --CHAT_MSG_MONSTER_YELL
+    bar_phase1 = "第一阶段",
+	
+	trigger_phase2_1 = "祈求怜悯！", --CHAT_MSG_MONSTER_YELL
+	trigger_phase2_2 = "尖叫出你的临终呼吸！", --CHAT_MSG_MONSTER_YELL
+	trigger_phase2_3 = "末日就在你身上！", --CHAT_MSG_MONSTER_YELL
+    bar_phase2 = "克尔苏加德激活",
+    msg_phase2 = "第二阶段 - 15秒后克尔苏加德激活！",
+	
+    msg_phase3soon = "即将进入第三阶段 - 在40%血量时开始",
+	
+	trigger_phase3 = "掌握！我需要援助！", --CHAT_MSG_MONSTER_YELL
+    msg_phase3 = "第三阶段 - 5个小强即将到来 - 最多束缚 3 个！",
+	
+	--supposedly 14 of each, saw 13 weaver in logs. Also 117 Soldier of the Frozen Wastes, useful?
+    bar_abom = "/14 憎恶死亡",
+    bar_weaver = "/14 女妖死亡",
+	
+    msg_abom = "憎恶已刷新 ",
+    msg_weaver = "女妖已刷新 ",
+		
+	trigger_mcYell1 = "你的灵魂，现在与我绑定了！",
+	trigger_mcYell2 = "将无处可逃！",
+    msg_mc = "精神控制！",
+	
+	trigger_mcYou = "你受到了克尔苏加德锁链效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_mcOther = "(.+)受到了克尔苏加德锁链效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_mcFade = "克尔苏加德的锁链效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mcAfflic = " 精神控制",
+    bar_mcCd = "精神控制 CD",
+	trigger_friendlyDead = "(.+)死亡了。", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	
+	trigger_fissure = "克尔苏加德施放了暗影裂隙。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_fissure = "离开红圈！",
+    msg_fissure = "红圈！",
+	
+	trigger_frostBlastYell = "我要冻结你血管里的血液！", --CHAT_MSG_MONSTER_YELL
+	trigger_frostBlastYou = "你受到了冰霜冲击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_frostBlastOther = "(.+)受到了冰霜冲击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE, CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+    bar_frostBlastCd = "冰墓 CD",
+    bar_frostBlastAfflic = "冰墓",
+    msg_frostBlast = "冰墓！",
+		--unused
+	trigger_frostBlastFade = "冰霜冲击效果从(.+)身上消失。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+
+	trigger_detonateYou = "你受到了自爆法力效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_detonateOther = "(.+)受到了自爆法力效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_detonateFade = "自爆法力效果从(.+)身上消失。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_detonateAfflic = " 法力爆炸",
+	bar_detonateCd = "法力爆炸 CD",
+	msg_detonate = "法力爆炸在 ",
+
+	trigger_frostbolt = "克尔苏加德开始施放冰霜箭。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_frostbolt = "冰霜箭",
+	msg_frostbolt = "冰霜箭 - 打断！",
+	
+	trigger_attack1 = "克尔苏加德击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack2 = "克尔苏加德没有击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack3 = "克尔苏加德击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_attack4 = "克尔苏加德的致命一击", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_kick1 = "脚踢击中克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick2 = "脚踢对克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick3 = "脚踢被克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel1 = "拳击击中克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel2 = "拳击对克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel3 = "拳击被克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash1 = "盾击击中克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash2 = "盾击对克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash3 = "盾击被克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock1 = "地震术击中克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock2 = "地震术致命一击对克尔苏加德", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	
+	trigger_volley = "克尔苏加德的群体寒冰箭击中", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	bar_volley = "群体寒冰箭 CD",
+
+	bar_guardian = "小强 %d",
+
+	trigger_shackle = "寒冰皇冠卫士受到了束缚亡灵效果的影响。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+	trigger_shackleFade = "束缚亡灵效果从寒冰皇冠卫士身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_shackle = "束缚亡灵（最多3个）",
+	msg_shackle = "%s/3",
+
+	trigger_bloodTap = "寒冰皇冠卫士获得了鲜血分流的效果%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_bloodTapA = "血液分流 +",
+	bar_bloodTapB = "% 伤害",
+	clickme = " >点击我！<",
+	you = "你",
+
+} end )
 local timer = {
 	speedRod = 160,
 	phase1 = 320,

--- a/Raids/Naxxramas/LivingMonstrosity.lua
+++ b/Raids/Naxxramas/LivingMonstrosity.lua
@@ -28,6 +28,26 @@ L:RegisterTranslations("enUS", function() return {
 	msg_totemDead = "Totem is dead =)",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Monstrosity",
+
+    lightningtotem_cmd = "lightningtotem",
+    lightningtotem_name = "闪电图腾警报",
+    lightningtotem_desc = "召唤闪电图腾时进行警告",
+
+    autotarget_cmd = "autotarget",
+    autotarget_name = "自动目标闪电图腾",
+    autotarget_desc = "召唤图腾时自动选择为目标",
+
+    trigger_totemUp = "畸形妖开始施放闪电图腾。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_totemUp = "转火闪电图腾！",
+
+    trigger_totemDead = "闪电图腾死亡了。",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+    msg_totemDead = "图腾死了 =)",
+} end )
 local timer = {
 }
 local icon = {

--- a/Raids/Naxxramas/Loatheb.lua
+++ b/Raids/Naxxramas/Loatheb.lua
@@ -169,6 +169,93 @@ LoathebDebuff:Hide()
 LoathebDebuff:SetFrameStrata("TOOLTIP")
 LoathebDebuff:SetOwner(WorldFrame, "ANCHOR_NONE")
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Loatheb",
+
+	doom_cmd = "doom",
+    doom_name = "必然厄运警报",
+    doom_desc = "必然厄运出现时进行警告",
+
+    curse_cmd = "curse",
+    curse_name = "厄运爆炸警报",
+    curse_desc = "必然厄运爆炸时进行警告",
+
+	spore_cmd = "spore",
+    spore_name = "孢子警报",
+    spore_desc = "孢子生成时进行警告",
+
+	debuff_cmd = "debuff",
+    debuff_name = "孢子效果",
+    debuff_desc = "当你的孢子效果即将消失时显示图标",
+
+	groups_cmd = "groups",
+    groups_name = "孢子分组",
+    groups_desc = "关闭以在孢子计时器上显示分组编号（7组战术）",
+	
+	corruptedmind_cmd = "堕落心灵开始",
+    corruptedmind_name = "个人堕落心灵计时器",
+    corruptedmind_desc = "你的堕落心灵减益效果的计时器",
+	
+	
+    doombar = "必然厄运 %d",
+    doomwarn = "必然厄运%d！距下一次%d秒！",
+    doomwarn5sec = "5秒后必然厄运%d！",
+    doomtrigger = "受到了必然的厄运效果的影响。",
+
+	cursewarn = "下一次喷毒！",
+    cursebar = "毒性光环",
+    cursetrigger  = "受到了毒性光环效果的影响。",
+
+	doomtimerbar = "每15秒一次厄运（狂暴）",
+    doomtimerwarn = "厄运计时器在 %s 秒后改变！",
+    doomtimerwarnnow = "必然厄运现在每15秒发生一次！",
+
+    cursetimerbar = "必然厄运计时器",
+    cursetimerwarn = "厄运爆炸，下一次在 %s 秒后！",
+
+    startwarn = "洛欧塞布已激活，2分钟后将出现必然厄运！",
+	
+	trigger_corruptedMind = "你受到了堕落心灵效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_corruptedMind = "你的堕落心灵倒计时",
+	trigger_corruptedMindFade = "堕落心灵效果从你身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	--sporewarn = "Spore spawned",
+    sporebar = "下一个孢子 %d",
+    sporebar_group = "下一孢子 - 分组 %d",
+
+    you = "你",
+    are = "受到了",
+	fungalBloom = "蘑菇花",
+
+	--LoathebTactical
+	graphic_cmd = "graphic",
+    graphic_name = "图形标志",
+    graphic_desc = "选中后显示图形标志",
+
+	sound_cmd = "sound",
+    sound_name = "声效",
+    sound_desc = "选中后播放声效",
+
+	consumable_cmd = "consumable",
+    consumable_name = "不警告团队使用消耗品（A）",
+    consumable_desc = "选中后不通过团队警告来提示使用消耗品。需要助理权限（A）",
+
+    shadowpot = "-- 喝暗抗！ --",
+    bandage = "-- 使用绷带！ --",
+    wrtorhs = "-- 喝糖水茶/吃糖！ --",
+    shadowpotandbandage = "-- 喝暗抗并用绷带！ --",
+    noconsumable = "-- 现在不用消耗品！ --",
+
+	soundshadowpot = "Interface\\Addons\\BigWigs\\Sounds\\potion.wav",
+	soundbandage = "Interface\\Addons\\BigWigs\\Sounds\\bandage.wav",
+	soundwrtorhs = "Interface\\Addons\\BigWigs\\Sounds\\healthstone.wav",
+	soundshadowpotandbandage = "Interface\\Addons\\BigWigs\\Sounds\\potionandbandage.wav",
+	soundgoforbuff = "Interface\\Addons\\BigWigs\\Sounds\\goforbuff.wav",
+
+} end )
 local timer = {
 	softEnrage = 300,
 	firstDoom = 120,

--- a/Raids/Naxxramas/Maexxna.lua
+++ b/Raids/Naxxramas/Maexxna.lua
@@ -60,6 +60,62 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Maexxna",
+	
+	cocoon_cmd = "cocoon",
+    cocoon_name = "蛛网之茧警报",
+    cocoon_desc = "警告被蛛网之茧的玩家",
+
+    webspray_cmd = "spray",
+    webspray_name = "撒网警报",
+    webspray_desc = "即将撒网时进行警告",
+
+    poison_cmd = "Poison",
+    poison_name = "死灵之毒警报",
+    poison_desc = "死灵之毒出现时进行警告",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+
+    spiderlings_cmd = "spiderlings",
+    spiderlings_name = "小蜘蛛警报",
+    spiderlings_desc = "小蜘蛛出现时进行警告",
+
+
+	trigger_cocoonGain = "(.+)受到了蛛网之茧效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_cocoonGainYou = "你受到了蛛网之茧效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_cocoonFade = "蛛网之茧效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_cocoonGain = "蛛网之茧",
+    bar_cocoonCD = "蛛网之茧 CD",
+
+	trigger_webSprayGain = "受到了蛛网喷射效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_webSprayGain = "群体被网",
+    bar_webSprayCD = "群体蛛网 CD",
+	
+	trigger_webSprayFade = "蛛网喷射效果从",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+
+	trigger_poisonGain = "受到了死灵之毒效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_poisonGain = "死灵之毒持续！",
+    bar_poisonCD = "死灵之毒 CD",
+	
+	trigger_poisonFade = "死灵之毒效果从",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_enrageGain = "迈克斯纳获得了激怒的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrageGain = "迈克斯纳激怒了！",
+    msg_enrageSoon = "迈克斯纳血量低于35% - 30%时会激怒！",
+	
+    bar_spiderlings = "小蜘蛛",
+	
+	--spray every 40sec
+		--last for 8sec
+	--cocoon after 20sec
+	--lings after 35sec
+} end )
 local timer = {
 	cocoonDuration = 600,
 	cocoonCD = 20,

--- a/Raids/Naxxramas/Noth.lua
+++ b/Raids/Naxxramas/Noth.lua
@@ -57,6 +57,60 @@ L:RegisterTranslations("enUS", function() return {
 	bar_teleport = "Teleport",	
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Noth",
+
+    blink_cmd = "blink",
+    blink_name = "闪现警报",
+    blink_desc = "闪现时进行警告",
+
+    teleport_cmd = "teleport",
+    teleport_name = "传送警报",
+    teleport_desc = "传送时进行警告",
+
+    curse_cmd = "curse",
+    curse_name = "诅咒警报",
+    curse_desc = "诅咒时进行警告",
+    
+    cripple_cmd = "cripple",
+    cripple_name = "残废术警报",
+    cripple_desc = "残废术生效时进行警告",
+    
+    wave_cmd = "wave",
+    wave_name = "小怪警报",
+    wave_desc = "小怪来袭时进行警告",
+
+	trigger_start1 = "Die, trespasser!",
+	trigger_start2 = "Glory to the master!",
+	trigger_start3 = "Your life is forfeit!",
+	
+	trigger_curse1 = "受到了瘟疫使者的诅咒效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_curse2 = "瘟疫使者的诅咒效果从你身上消失了。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_curse = "诅咒！",
+    bar_curse = "诅咒冷却",
+	
+	trigger_cripple1 = "受到了残废术效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_cripple2 = "残废术效果从你身上消失了。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_cripple = "残废术！",
+    bar_cripple = "残废术冷却",
+	
+	trigger_blink = "瘟疫者诺斯获得了闪现术的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_blink = "闪现！",
+    bar_blink = "闪现冷却",
+	
+	trigger_add = "起来吧，我的士兵们！奋起再战！",
+    bar_roomWave = "3个被感染的战士",
+	
+    bar_wave1 = "第1波",
+    bar_wave2 = "第2波",
+	
+    msg_tpToBalcony = "传送！他在阳台上！",
+    msg_tpToRoom = "回到房间中！",
+    bar_teleport = "传送",
+} end )
 local timer = {
 	firstCurse = {8,12},
 	curseAfterTeleport = {2,10},

--- a/Raids/Naxxramas/Patchwerk.lua
+++ b/Raids/Naxxramas/Patchwerk.lua
@@ -27,6 +27,26 @@ L:RegisterTranslations("enUS", function() return {
 	msg_enrage = "Enrage!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Patchwerk",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒时进行警告",
+	
+	trigger_start1 = "帕奇维克想玩！",
+	trigger_start2 = "克尔苏加德让帕奇维克成为他的战争化身！",
+	
+	trigger_enrage = "陷入狂暴状态！",--CHAT_MSG_MONSTER_EMOTE
+	
+    bar_enrage = "激怒",
+    msg_enrage60 = "60秒后激怒",
+    msg_enrage10 = "10秒后激怒",
+    msg_enrage = "激怒！",
+} end )
 local timer = {
 	enrage = 420,
 }

--- a/Raids/Naxxramas/Razuvious.lua
+++ b/Raids/Naxxramas/Razuvious.lua
@@ -43,6 +43,45 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Razuvious",
+
+    shout_cmd = "shout",
+    shout_name = "怒吼警报",
+    shout_desc = "瓦解怒吼时进行警告",
+
+    mc_cmd = "mc",
+    mc_name = "精神控制计时条",
+    mc_desc = "显示精神控制计时条",
+
+    unbalance_cmd = "unbalancing",
+    unbalance_name = "重压打击警报",
+    unbalance_desc = "重压打击出现时进行警告",
+
+    shieldwall_cmd = "shieldwall",
+    shieldwall_name = "盾墙计时器",
+    shieldwall_desc = "显示盾墙计时器",
+
+
+	trigger_shout = "%s发出胜利的呼喊。", --CHAT_MSG_RAID_BOSS_EMOTE
+    bar_shout = "瓦解怒吼",
+    msg_shout = "瓦解怒吼！",
+	
+	trigger_mcYou = "你获得了精神控制的效果。", --CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS
+	trigger_mcFadeYou = "精神控制效果从你身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    mc_bar = " 精神控制",
+    mcLocked_bar = "无法精神控制 ",
+	
+	trigger_unbalance = "受到了重压打击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_unbalance2 = "教官拉苏维奥斯的重压打击", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_unbalance = "重压打击",
+	
+	trigger_shieldWall = "死亡骑士学员获得了盾墙的效果。", --CHAT_MSG_SPELL_PERIODIC_PARTY_BUFFS // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_BUFFS
+    bar_shieldWall = "盾墙",
+} end )
 local timer = {
 	firstShout = 14, -- 1 sec buffer to be safe
 	shout = 25,

--- a/Raids/Naxxramas/Sapphiron.lua
+++ b/Raids/Naxxramas/Sapphiron.lua
@@ -96,6 +96,95 @@ L:RegisterTranslations("enUS", function() return {
 	msg_parryYou = "Sapphiron Parried your attack - Stop killing the tank you idiot!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Sapphiron",
+
+	frostbreath_cmd = "frostbreath",
+    frostbreath_name = "深呼吸警报",
+    frostbreath_desc = "当萨菲隆开始施放深呼吸时进行警告。",
+
+	lifedrain_cmd = "lifedrain",
+    lifedrain_name = "生命吸取警报",
+    lifedrain_desc = "生命吸取诅咒出现时进行警告",
+	
+	block_cmd = "block",
+    block_name = "冰块警报",
+    block_desc = "冰块出现时进行警告",
+	
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒状态出现时进行警告",
+
+	blizzard_cmd = "blizzard",
+    blizzard_name = "暴风雪警报",
+    blizzard_desc = "暴风雪出现时进行警告",
+	
+	tailsweep_cmd = "tailsweep",
+    tailsweep_name = "龙尾扫击警报",
+    tailsweep_desc = "龙尾扫击出现时进行警告",
+	
+	phase_cmd = "phase",
+    phase_name = "阶段转换警报",
+    phase_desc = "警告地面/空中阶段",
+	
+	proximity_cmd = "proximity",
+    proximity_name = "近距离警告",
+    proximity_desc = "显示近距离警告框架",
+	
+	parry_cmd = "parry",
+    parry_name = "招架警报",
+    parry_desc = "招架出现时进行警告",
+	
+	
+	trigger_frostBreath = "萨菲隆开始施放冰霜吐息。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_frostBreath = "核弹爆炸！",
+    msg_frostBreath = "即将遭受冰霜核弹 - 躲避！",
+	
+	trigger_lifeDrain = "受到了生命吸取效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_lifeDrainResist = "Life Drain was resisted by", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    msg_lifeDrain = "生命吸取，快驱散！",
+    bar_lifeDrain = "生命吸取",
+	
+	trigger_iceboltYou = "你受到了寒冰箭效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_iceboltOther = "(.+)受到了寒冰箭效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    msg_iceBlock = "冰冻术在 ",
+	
+		--unused
+	trigger_iceboltFade = "寒冰箭效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	
+	trigger_iceboltHits = "萨菲隆的寒冰箭击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    --bar_iceBlock1 = "冰块 1",
+    bar_iceBlock2 = "冰块 2",
+    bar_iceBlock3 = "冰块 3",
+    bar_iceBlock4 = "冰块 4",
+    bar_iceBlock5 = "冰块 5",
+	
+	trigger_enrage = "萨菲隆获得了狂暴的效果。", --to be confirmed
+    bar_enrage = "狂暴",
+    msg_enrage60 = "距离狂暴还有60秒！",
+    msg_enrage10 = "距离狂暴还有10秒！",
+	
+	
+	trigger_blizzardYou = "你受到了寒冷效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_blizzardYouFade = "寒冷效果从你身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_tailSweepYou = "萨菲隆的龙尾扫击击中你", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_tailSweep = "离开尾部的30码区域！",
+	
+    bar_timeToAirPhase = "下一空中阶段 CD",
+    --msg_airPhase = "空中阶段 - 分散！",
+    msg_airPhaseSoon = "空中阶段即将来临 - 准备分散！",
+    bar_timeToGroundPhase = "下一地面阶段",
+    msg_groundPhase = "地面阶段！",
+	
+    msg_lowHp = "萨菲隆血量低于10% - 不再有空中阶段！",
+	
+	trigger_parryYou = "你发起了攻击。萨菲隆招架住了。", --CHAT_MSG_COMBAT_SELF_MISSES
+    msg_parryYou = "你的攻击被萨菲隆招架了 - 别再当坦克了，笨蛋！",
+} end )
 local timer = {
 	frostBreath = 7,
 	firstLifeDrain = 12,

--- a/Raids/Naxxramas/SpiderTrash.lua
+++ b/Raids/Naxxramas/SpiderTrash.lua
@@ -22,6 +22,21 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "SpiderTrash",
+
+    charge_cmd = "charge",
+    charge_name = "毒性充能",
+    charge_desc = "显示毒性充能的冷却时间和图标。",
+    
+    charge_trigger = "受到了毒性充能效果的影响。",
+    chargeself_trigger = "你受到了毒性充能效果的影响。",
+    chargegone_self = "毒性充能效果从你身上消失",
+    charge_bar = "毒性充能 CD",
+} end )
 local timer = {
 	charge = { 10, 15 },
 }

--- a/Raids/Naxxramas/Thaddius.lua
+++ b/Raids/Naxxramas/Thaddius.lua
@@ -102,6 +102,80 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Thaddius",
+	
+	power_cmd = "power",
+	power_name = "能量涌动警报",
+	power_desc = "斯塔拉格能量涌动时进行警告",
+	
+	magneticPull_cmd = "magneticPull",
+	magneticPull_name = "磁性吸引警报",
+	magneticPull_desc = "磁性吸引时进行警告",
+	
+	manaburn_cmd = "manaburn",
+	manaburn_name = "静止力场警报",
+	manaburn_desc = "静止力场时进行警告",
+	
+	phase_cmd = "phase",
+	phase_name = "阶段警报",
+	phase_desc = "阶段转换时进行警告",
+	
+	enrage_cmd = "enrage",
+	enrage_name = "激怒警报",
+	enrage_desc = "激怒出现时进行警告",
+
+	polarity_cmd = "polarity",
+	polarity_name = "极性转换警报",
+	polarity_desc = "极性转换时进行警告",
+
+	selfcharge_cmd = "selfcharge",
+	selfcharge_name = "电荷变化警报",
+	selfcharge_desc = "你的正/负电荷变化时进行警告。",
+
+	
+	trigger_engage = "斯塔拉格碾压你！", --CHAT_MSG_MONSTER_YELL
+	trigger_engage1 = "喂你当主人！", --CHAT_MSG_MONSTER_YELL
+	
+	trigger_powerSurge = "斯塔拉格获得了能量涌动的效果。",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_powerSurge = "能量涌动",
+	msg_powerSurge = "斯塔拉格获得能量涌动！",
+	
+	bar_magneticPull = "磁性吸引",
+	
+	trigger_manaBurn = "费尔根的静止力场击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	trigger_manaBurn2 = "You absorb Feugen's Static Field.",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	msg_manaBurn = "费尔根的静止力场！30码范围AOE",
+	
+	trigger_feugenDeadYell = "不...更多...费根...",--CHAT_MSG_MONSTER_YELL
+	trigger_stalaggDeadYell = "主宰救救我吧...",--CHAT_MSG_MONSTER_YELL
+	
+	trigger_3sec = "%s 超载！",--CHAT_MSG_RAID_BOSS_EMOTE
+	bar_phase2 = "塔迪乌斯激活",
+	msg_phase2 = "第二阶段",
+	msg_positionReminder = "+ + + + +  塔迪乌斯  - - - - -",
+	
+	trigger_enrage = "塔迪乌斯获得了狂暴的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_enrage = "狂暴",
+	msg_enrage = "狂暴！",
+	msg_enrage60 = "60秒后狂暴",
+	msg_enrage10 = "10秒后狂暴",
+	
+	trigger_polarityShiftCast = "塔迪乌斯开始施放极性转化。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_polarityShiftCast = "开始极性转换",
+	msg_polarityShift = "正在施放极性转换！",
+	
+	trigger_polarityShiftAfflic = "现在你感到疼痛了！", --CHAT_MSG_MONSTER_YELL
+	bar_polarityShiftCd = "极性转换倒计时",
+	
+	msg_noChange = "你的增益效果没有变化！",
+	msg_changeToPositive = "你变成了正电荷！",
+	msg_changeToNegative = "你变成了负电荷！",
+	bar_polarityTick = "跑位时间",
+} end )
 local timer = {
 	powerSurge = 10,
 	magneticPull = 20.5,

--- a/Raids/Onyxia/Onyxia.lua
+++ b/Raids/Onyxia/Onyxia.lua
@@ -17,6 +17,58 @@ module.zonename = {
 --      Module specific Locals --
 ---------------------------------
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Onyxia",
+    engage_trigger = "必须离开巢穴去觅食",
+
+    deepbreath_cmd = "deepbreath",
+    deepbreath_name = "深呼吸警报",
+    deepbreath_desc = "奥妮克希亚开始施放深呼吸时进行警告",
+
+    flamebreath_cmd = "flamebreath",
+    flamebreath_name = "烈焰吐息警报",
+    flamebreath_desc = "奥妮克希亚开始施放烈焰吐息时进行警告",
+
+    wingbuffet_cmd = "wingbuffet",
+    wingbuffet_name = "龙翼打击警报",
+    wingbuffet_desc = "龙翼打击出现时进行警告",
+
+    fireball_cmd = "fireball",
+    fireball_name = "火球术警报",
+    fireball_desc = "火球术出现时进行警告",
+
+    phase_cmd = "phase",
+    phase_name = "阶段警报",
+    phase_desc = "阶段改变时进行警告",
+
+    onyfear_cmd = "onyfear",
+    onyfear_name = "低沉咆哮警报",
+    onyfear_desc = "第三阶段低沉咆哮时进行警告",
+
+    deepbreath_trigger = "深吸了一口气",
+    flamebreath_trigger = "奥妮克希亚开始施放火息术。",
+    wingbuffet_trigger = "奥妮克希亚开始施放龙翼攻击。",
+    fireball_trigger = "奥妮克希亚开始施放火球术。",
+    phase2_trigger = "从上面把你们",
+    phase3_trigger = "看来你还需要再上一课",
+    fear_trigger = "奥妮克希亚开始施放低沉咆哮。",
+    fear_over_trigger = "低沉咆哮" ,
+
+    warn1 = "深呼吸即将到来！",
+    phase1text = "第一阶段",
+    phase2text = "第二阶段",
+    phase3text = "第三阶段",
+    feartext = "即将恐惧！",
+    fear_cast = "低沉咆哮",
+    fear_next = "下一次低沉咆哮",
+    deepbreath_cast = "深呼吸",
+    flamebreath_cast = "烈焰吐息",
+    wingbuffet_cast = "龙翼打击",
+	fireball_cast = "火球目标 %s",
+} end )
 local timer = {
 	firstFear = 5,
 	fear = 15,

--- a/Raids/Other/Atiesh.lua
+++ b/Raids/Other/Atiesh.lua
@@ -53,6 +53,52 @@ L:RegisterTranslations("enUS", function() return {
 	--trigger_eyeOfNaxxDead = "Eye of Naxxramas dies." --CHAT_MSG_COMBAT_HOSTILE_DEATH
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	cmd = "Atiesh",
+
+	unholyaura_cmd = "unholyaura",
+	unholyaura_name = "邪恶光环警报",
+	unholyaura_desc = "邪恶光环时进行警告",
+
+	shadowbolt_cmd = "shadowbolt",
+	shadowbolt_name = "暗影箭警报",
+	shadowbolt_desc = "暗影箭时进行警告",
+	
+	breathofsargeras_cmd = "breathofsargeras",
+	breathofsargeras_name = "萨格拉斯之息警报",
+	breathofsargeras_desc = "萨格拉斯之息时进行警告",
+	
+	
+	--is engage trigger, aura hits every 2 sec
+	trigger_gainAura = "埃提耶什获得了邪恶光环的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	
+	--every 2sec
+	trigger_auraHits = "埃提耶什的邪恶光环击中",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+	bar_unholyAura = "邪恶光环",
+	
+	trigger_shadowBolt = "埃提耶什开始施放暗影箭。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_shadowBoltCd = "暗影箭冷却",
+	bar_shadowBoltCast = "施放暗影箭！",
+	
+	trigger_breathOfSargerasCast = "埃提耶什开始施展萨格拉斯之息。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_breathOfSargerasCd = "萨格拉斯之息冷却",
+	bar_breathOfSargerasCast = "施放萨格拉斯之息",
+	msg_breathOfSargeras = "萨格拉斯之息 - 驱散（仅近战和猎人）",
+	
+	trigger_breathOfSargerasYou = "你受到了萨格拉斯之息效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE   You are afflicted by Breath of Sargeras(1)...
+	bar_breathOfSargerasAfflic = " 被诅咒",
+	
+	trigger_breathOfSargerasFadeYou = "萨格拉斯之息效果从你身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	trigger_breathOfSargerasFadeOther = "萨格拉斯之息效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_PARTY
+	
+	
+	trigger_eyeOfNaxx = "这儿有活人！", --CHAT_MSG_MONSTER_YELL
+	bar_eyeOfNaxx = "纳克萨玛斯之眼！",
+	--trigger_eyeOfNaxxDead = "Eye of Naxxramas dies." --CHAT_MSG_COMBAT_HOSTILE_DEATH
+	EyeofNaxxramas = "纳克萨玛斯之眼",
+	Atiesh = "埃提耶什",
+} end )
 local timer = {
 	unholyAura = 2,
 	

--- a/Raids/Other/Azuregos.lua
+++ b/Raids/Other/Azuregos.lua
@@ -78,6 +78,78 @@ L:RegisterTranslations("enUS", function() return {
 	["You have slain %s!"] = true,
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Azuregos",
+	
+	chill_cmd = "chill",
+    chill_name = "冰寒警报",
+    chill_desc = "冰寒出现时进行警告",
+
+    arcanevacuum_cmd = "arcanevacuum",
+    arcanevacuum_name = "奥术真空警报",
+    arcanevacuum_desc = "奥术真空（传送）出现时进行警告",
+
+    reflection_cmd = "reflection",
+    reflection_name = "反射警报",
+    reflection_desc = "反射出现时进行警告",
+
+    selfreflect_cmd = "selfreflect",
+    selfreflect_name = "你身上的反射警报",
+    selfreflect_desc = "法术被反射回你时警告",
+
+    manastorm_cmd = "manastorm",
+    manastorm_name = "法力风暴警报",
+    manastorm_desc = "法力风暴出现时进行警告",
+
+    frostbreath_cmd = "frostbreath",
+    frostbreath_name = "冰霜吐息警报",
+    frostbreath_desc = "冰霜吐息出现时进行警告",
+	
+	
+	--increasing the time between their attacks by 300%, and movement speed by 40%
+	trigger_chillYou = "You are afflicted by Chill.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_chillOther = "(.+) is afflicted by Chill.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_chillFade = "Chill fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_chillCd = "冰寒 CD",
+    bar_chillAfflic = " 受冰寒影响",
+    msg_chill = "冰寒 - 首先驱散坦克！",
+	
+	--teleport close players (data reports 30yd, players report 10yd, probably is 30yd from dead center)
+	  --and causes aggro wipe for the teleported players only
+	trigger_arcaneVacuum = "Come, little ones. Face me!", --CHAT_MSG_MONSTER_YELL
+    bar_arcaneVacuumCd = "奥术真空 CD",
+    bar_arcaneVacuumReady = "奥术真空准备...",
+    msg_arcaneVacuum = "奥术真空 - 传送 + 只对近战玩家清除仇恨！",
+	
+	--can be dispelled by felhunter, reflects spells
+	trigger_reflection = "Azuregos gains Reflection.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_reflectionFade = "Reflection fades from Azuregos.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_reflectionCd = "反射 CD",
+    bar_reflection = "反射！",
+    msg_reflectionUp = "反射 - 停止施法！",
+    msg_reflectionFade = "反射消失",
+	
+	trigger_reflectYou = "Your (.+) is reflected back by Azuregos.", --CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_reflectYou = "法术反射 - 停止自残！",
+	
+	--Blizzard-like AoE but burns mana
+	trigger_manaStormYou = "You are afflicted by Manastorm.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_manaStormYouFade = "Manastorm fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_manaStorm = "远离法力风暴！",
+	
+	--Frontal Cone, Dmg + slowMove + ManaBurn
+	trigger_frostBreathYou = "Azuregos's Frost Breath hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	trigger_frostBreathCast = "Azuregos begins to perform Frost Breath.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_frostBreathCd = "冰霜吐息 CD",
+    bar_frostBreathCast = "施放冰霜吐息！",
+    msg_frostBreath = "冰霜吐息 = 法力燃烧... 不要站在前面！",
+
+    ["You have slain %s!"] = "你杀死了%s！",
+    you = "you",
+} end )
 local timer = {
 	chillFirstCd = 14,
 	chillCd = 24,

--- a/Raids/Other/Concavius.lua
+++ b/Raids/Other/Concavius.lua
@@ -96,6 +96,95 @@ L:RegisterTranslations("enUS", function() return {
 		trigger_someoneDies = "Your struggle is futile.", --CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	cmd = "Concavius",
+
+	addhp_cmd = "addhp",
+	addhp_name = "古祖和梁血条",
+	addhp_desc = "显示古祖和梁的血条",
+	
+	shadowshock_cmd = "shadowshock",
+	shadowshock_name = "暗影震击警报",
+	shadowshock_desc = "暗影震击出现时进行警告",
+	
+	manaburn_cmd = "manaburn",
+	manaburn_name = "法力燃烧警报",
+	manaburn_desc = "法力燃烧出现时进行警告",
+	
+	veilofshadow_cmd = "veilofshadow",
+	veilofshadow_name = "暗影迷雾警报",
+	veilofshadow_desc = "暗影迷雾出现时进行警告",
+	
+	voidbolt_cmd = "voidbolt",
+	voidbolt_name = "虚空箭警报",
+	voidbolt_desc = "虚空箭出现时进行警告",
+	
+	piercingshadow_cmd = "piercingshadow",
+	piercingshadow_name = "刺骨暗影警报",
+	piercingshadow_desc = "刺骨暗影出现时进行警告",
+	
+	vacuum_cmd = "vacuum",
+	vacuum_name = "真空警报",
+	vacuum_desc = "真空出现时进行警告",
+	
+	
+	
+	trigger_engage = "Let the void claim you...", --CHAT_MSG_MONSTER_YELL
+	
+		--yells "Bask in the power of the infinite void!", happens at 30%, only gains Shadowform (1)?
+	trigger_p2 = "Concavius gains Shadowform", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	
+	trigger_shadowShock = "Concavius's Shadow Shock", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	bar_shadowShock = "暗影震击冷却",
+	msg_shadowShocking = "空卡维斯 < 30%: 不再使用法力燃烧 -> 施放暗影震击和更多刺骨暗影",
+	
+	--Mana Burn / Disorient
+	trigger_manaBurnCd = "Perish.", --CHAT_MSG_MONSTER_YELL
+	trigger_manaBurnAfflic = "afflicted by Mana Burn", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	bar_manaBurnCd = "法力燃烧冷却",
+	bar_manaBurnAfflic = "失神",
+	msg_manaBurn3 = "法力燃烧将在3秒后出现 - 快躲开!",
+	
+	trigger_veilOfShadow_you = "You are afflicted by Veil of Shadow", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_veilOfShadow_other = "(.+) is afflicted by Veil of Shadow", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_veilOfShadow_fade = "Veil of Shadow fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	bar_veilOfShadow = "暗影迷雾",
+	msg_veilOfShadow = "暗影迷雾 - 快解诅咒!",
+	
+		--2.6 - 3.2k dmg, 4.35 - 4.5sec cast, 9-12sec cd
+	trigger_voidBolt = "Concavius begins to cast Void Bolt.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_voidBoltCd = "虚空箭冷却",
+	bar_voidBoltCast = "正在施放虚空箭",
+	
+	trigger_piercingShadow_cast = "Concavius begins to cast Piercing Shadow.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_piercingShadow_you = "You are afflicted by Piercing Shadow", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_piercingShadow_other = "(.+) is afflicted by Piercing Shadow", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_piercingShadow_fade = "Piercing Shadow fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	bar_piercingShadowCd = "刺骨暗影冷却",
+	bar_piercingShadowCast = "正在施放刺骨暗影",
+	bar_piercingShadowAfflic = "刺骨暗影",
+	msg_piercingShadow = "刺骨暗影 - 快解诅咒!",
+	
+		--pulls everyone to him, 30sec cd, 20sec from start, can it be avoided?
+	trigger_vacuum = "Embrace the void!", --CHAT_MSG_MONSTER_YELL
+	bar_vacuum = "真空冷却",
+	
+	
+	--unused
+			--hits the tank every 3-5 seconds for 150-200 dmg
+		trigger_drainLife = "Concavius's Drain Life hits (.+) for", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+			
+			--only stacks to (1)? shadow bolt hits for 150 dmg, the DoT does 40dmg per 2 seconds, doesn't stack
+		trigger_shadowBoltStack_you = "You are afflicted by Shadow Bolt %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+		trigger_shadowBoltStack_other = "(.+) is afflicted by Shadow Bolt %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+		trigger_shadowBoltStack_fade = "Shadow Bolt fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+		
+			--does he gain a buff? or just like to nag?
+		trigger_someoneDies = "Your struggle is futile.", --CHAT_MSG_MONSTER_YELL
+		
+		["you"] = "你",
+} end )
 local timer = {
 	shadowShock = {8,16}, --saw 8.5, 9, 15.8
 	

--- a/Raids/Other/DarkReaverOfKarazhan.lua
+++ b/Raids/Other/DarkReaverOfKarazhan.lua
@@ -81,6 +81,82 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_engage = "You desecrate the Master's lands with your filthy footsteps!",--CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "DarkReaverOfKarazhan",
+
+    forlornspirit_cmd = "forlornspirit",
+    forlornspirit_name = "弃灵警报",
+    forlornspirit_desc = "弃灵增援时进行警告",
+
+    lurkingshadow_cmd = "lurkingshadow",
+    lurkingshadow_name = "潜伏暗影警报",
+    lurkingshadow_desc = "潜伏暗影增援时进行警告",
+    
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+    
+    deterrence_cmd = "deterrence",
+    deterrence_name = "威慑警报",
+    deterrence_desc = "威慑出现时进行警告",
+    
+    nimblereflexes_cmd = "nimblereflexes",
+    nimblereflexes_name = "迅捷反射警报",
+    nimblereflexes_desc = "迅捷反射出现时进行警告",
+    
+    unbalancingstrike_cmd = "unbalancingstrike",
+    unbalancingstrike_name = "重压打击警报",
+    unbalancingstrike_desc = "重压打击出现时进行警告",
+    
+    piercearmor_cmd = "piercearmor",
+    piercearmor_name = "破甲警报",
+    piercearmor_desc = "破甲出现时进行警告",
+    
+    
+        --4 adds, yells every 20secs, spawns 2sec * count later (1st = 2sec, 2nd = 4sec, 3rd = 6sec, 4th = 8sec... later)
+    trigger_forlornSpiritSpawn = "Spirits, rise, and drive back this rabble!",--CHAT_MSG_MONSTER_YELL
+    trigger_forlornSpiritSpawn2 = "Rise, spirits. Defend the Master's lands!",--CHAT_MSG_MONSTER_YELL
+    bar_forlornSpiritSpawnCd = "4个弃灵",
+    msg_forlornSpiritSpawn = "4个弃灵已出现！",
+
+        --shaman (no caps)
+        --spawns a Lurking Shadow, can be killed by only THAT class
+    trigger_lurkingShadowSpawn = "A (.+) shadow appears next to (.+)...",--CHAT_MSG_MONSTER_EMOTE
+    bar_lurkingShadowSpawn = "潜伏暗影",
+        -- SHAMAN! --  Lurking Shadow!
+    msg_lurkingShadowSpawn = " 潜伏暗影！",
+    
+    trigger_enrage = "Dark Reaver of Karazhan gains Furious Anger.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+
+        --25% dodge and parry, 10sec
+    trigger_deterrence = "Dark Reaver of Karazhan gains Deterrence.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_deterrenceFade = "Deterrence fades from Dark Reaver of Karazhan.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_deterrence = "威慑 25% 闪避/招架",
+    
+        --75% parry, 8sec
+    trigger_nimbleReflexes = "Dark Reaver of Karazhan gains Nimble Reflexes.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_nimbleReflexesFade = "Nimble Reflexes fades from Dark Reaver of Karazhan.",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_nimbleReflexes = "迅捷反射 75% 招架",
+
+        --6sec
+    trigger_unbalancingStrike = "(.+) is afflicted by Unbalancing Strike.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_unbalancingStrikeYou = "You are afflicted by Unbalancing Strike.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_unbalancingStrikeFade = "Unbalancing Strike fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_unbalancingStrike = " 重压打击",
+    
+        -- -50% or -75% armor, 20sec
+    trigger_pierceArmor = "(.+) is afflicted by Pierce Armor.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_pierceArmorYou = "You are afflicted by Pierce Armor.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_pierceArmorFade = "Pierce Armor fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_pierceArmor = " 破甲",
+
+    trigger_engage = "You desecrate the Master's lands with your filthy footsteps!",--CHAT_MSG_MONSTER_YELL
+    clickme = " >点击我！<",
+    you = "you",
+} end )
 local timer = {
 	--forlornSpiritSpawnCd = 22,
 	lurkingShadowSpawn = 10,

--- a/Raids/Other/DrWeavil.lua
+++ b/Raids/Other/DrWeavil.lua
@@ -33,6 +33,33 @@ L:RegisterTranslations("enUS", function() return {
 	bar_mc = " MC",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "DoctorWeavil",
+
+    mindshatter_cmd = "mindshatter",
+    mindshatter_name = "心灵碎裂警报",
+    mindshatter_desc = "心灵碎裂时进行警告",
+
+    mc_cmd = "mc",
+    mc_name = "精神控制警报",
+    mc_desc = "精神控制时进行警告",
+    
+
+        --AoE, 10sec CD, casts 0-6sec after, AoE 30 yards, 1k ish shadow damage + stun
+    trigger_mindShatter = "'s Mind Shatter", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_mindShatterCd = "心灵碎裂 CD",
+    bar_mindShatterSoon = "心灵碎裂 即将到来...",
+    
+    trigger_mcYou = "You are afflicted by Mental Domination.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_mcOther = "(.+) is afflicted by Mental Domination.", --CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_mcFade = "Mental Domination fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mc = " 精神控制",
+    clickme = " >点击我！<",
+    you = "you",
+} end )
 local timer = {
 	mindShatterCd = 10,
 	mindShatterSoon = 6,

--- a/Raids/Other/Emeriss.lua
+++ b/Raids/Other/Emeriss.lua
@@ -79,6 +79,76 @@ L:RegisterTranslations("enUS", function() return {
 	msg_corruptionSoon = "Corruption of the Earth Soon",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Emeriss",
+
+    tailsweep_cmd = "tailsweep",
+    tailsweep_name = "龙尾扫击警报",
+    tailsweep_desc = "龙尾扫击出现时进行警告",
+
+    dreamfog_cmd = "dreamfog",
+    dreamfog_name = "梦境迷雾昏睡警报",
+    dreamfog_desc = "梦境迷雾昏睡出现时进行警告",
+
+    noxiousbreath_cmd = "noxiousbreath",
+    noxiousbreath_name = "毒性吐息警报",
+    noxiousbreath_desc = "毒性吐息出现时进行警告",
+
+    sporecloud_cmd = "sporecloud",
+    sporecloud_name = "孢子云警报",
+    sporecloud_desc = "孢子云出现时进行警告",
+
+    volatileinfection_cmd = "volatileinfection",
+    volatileinfection_name = "快速传染警报",
+    volatileinfection_desc = "快速传染出现时进行警告",
+
+    corruption_cmd = "corruption",
+    corruption_name = "大地的堕落警报",
+    corruption_desc = "大地的堕落出现时进行警告",
+	
+
+	trigger_engage = "Hope is a DISEASE of the soul! This land shall wither and die!", --CHAT_MSG_MONSTER_YELL
+	
+	--self
+	trigger_tailSweepYou = "Tail Sweep hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_tailSweepYou = "龙尾扫击 - 不要站在龙的后面！",
+	
+	--self
+	trigger_dreamFogYou = "You are afflicted by Sleep.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_dreamFogYouFade = "Sleep fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_dreamFogYou = "梦境迷雾昏睡 - 不要站在梦境迷雾之中！",
+
+	--if nox you, for loop, find bossTarget, if bossTarget not you then WarningSign + msg only tank should
+	trigger_noxiousBreathYou = "You are afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathOther = "(.+) is afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_noxiousBreathCd = "毒性吐息 CD",
+    msg_noxiousBreathYou = "毒性吐息 - 不要站在龙的前面！",
+
+	--if is 3+ then bar
+	trigger_noxiousBreathStackYou = "You are afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathStackOther = "(.+) is afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_noxiousBreathFade = "Noxious Breath fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_noxiousBreath = " 毒性吐息",
+	
+	--when someone dies, they become a spore cloud, everyone around takes high damage
+		--Explode? DoT? Afflic?
+	trigger_sporeCloud = "To Be Determined", --TBD
+	
+	trigger_volatileInfectionYou = "You are afflicted by Volatile Infection.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_volatileInfectionOther = "(.+) is afflicted by Volatile Infection.",  --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE //CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_volatileInfectionFade = "Volatile Infection fades from (.+).",  --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_volatileInfection = " 快速传染",
+    msg_volatileInfection = "快速传染 - 净化疾病！",
+
+	trigger_corruption = "Taste your world's corruption!", --CHAT_MSG_MONSTER_YELL
+    bar_corruption = "大地的堕落",
+    msg_corruption = "大地的堕落 - 每2秒伤害提高20% - 补充治疗！",
+    msg_corruptionSoon = "大地的堕落即将来临",
+    you = "you",
+} end )
 local timer = {
 	dreamFog = 5,
 	

--- a/Raids/Other/Kazzak.lua
+++ b/Raids/Other/Kazzak.lua
@@ -72,6 +72,76 @@ L:RegisterTranslations("enUS", function() return {
 	msg_corruptSoul = " Healed Lord Kazzak by dying!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Kazzak",
+
+    berserk_cmd = "berserk",
+    berserk_name = "狂暴警报",
+    berserk_desc = "狂暴出现时进行警告。",
+
+    markofkazzak_cmd = "markofkazzak",
+    markofkazzak_name = "卡扎克印记警报",
+    markofkazzak_desc = "卡扎克印记（法力吸取减益）出现时进行警告。",
+
+    puticon_cmd = "puticon",
+    puticon_name = "标记卡扎克印记目标的团队图标",
+    puticon_desc = "在获得卡扎克印记的人身上放置团队图标。\n\n（需要助理或更高权限）",
+
+    twistedreflection_cmd = "twistedreflection",
+    twistedreflection_name = "扭曲反射警报",
+    twistedreflection_desc = "扭曲反射（每次击中治疗卡扎克25k生命值）出现时进行警告。",
+
+    voidbolt_cmd = "voidbolt",
+    voidbolt_name = "虚空箭警报",
+    voidbolt_desc = "虚空箭出现时进行警告。",
+
+    corruptsoul_cmd = "corruptsoul",
+    corruptsoul_name = "腐蚀灵魂警报",
+    corruptsoul_desc = "当卡扎克因随机死亡而得到治疗时进行警告。",
+
+    lowmana_cmd = "lowmana",
+    lowmana_name = "低法力警报",
+    lowmana_desc = "当你的法力值过低时进行警告。",
+	
+	
+	trigger_engage1 = "All mortals will perish!", --CHAT_MSG_MONSTER_YELL
+	trigger_engage2 = "The Legion will conquer all!", --CHAT_MSG_MONSTER_YELL
+	trigger_bossDead = "The Legion... will never... fall.", --CHAT_MSG_MONSTER_YELL
+	
+	trigger_berserk = "Lord Kazzak gains Berserk.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS to be confirmed
+    bar_berserk = "狂暴",
+    msg_berserk60 = "1分钟后狂暴！",
+    msg_berserk10 = "10秒后狂暴！",
+    msg_berserk = "狂暴！",
+	
+	trigger_markOfKazzakYou = "You are afflicted by Mark of Kazzak.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_markOfKazzakOther = "(.+) is afflicted by Mark of Kazzak.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_markOfKazzakFade = "Mark of Kazzak fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_markOfKazzakCd = "卡扎克印记 CD",
+    bar_markOfKazzakDur = " 卡扎克印记",
+    msg_markOfKazzak = " 被卡扎克印记 - 驱散！",
+    msg_markOfKazzakYou = "你中了卡扎克印记 - 法力不能耗尽！",
+    msg_lowMana = "警告 - 你的法力很低 - 卡扎克印记可能致命！",
+	
+	trigger_twistedReflectionYou = "You are afflicted by Twisted Reflection.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_twistedReflectionOther = "(.+) is afflicted by Twisted Reflection.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_twistedReflectionFade = "Twisted Reflection fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_twistedReflectionCd = "扭曲反射 CD",
+    bar_twistedReflectionDur = " 扭曲反射",
+    msg_twistedReflection = " 被扭曲反射 - 驱散！",
+	
+	trigger_voidBolt = "Lord Kazzak begins to cast Void Bolt.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_voidBoltCd = "虚空箭 CD",
+    bar_voidBoltCast = "虚空箭！",
+		
+	trigger_deadYou = "You die.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	trigger_deadOther = "(.+) dies.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+    msg_corruptSoul = " 死亡治疗了魔王卡扎克！",
+    you = "you",
+} end )
 local timer = {
 	berserk = 180,
 	

--- a/Raids/Other/Lethon.lua
+++ b/Raids/Other/Lethon.lua
@@ -73,6 +73,70 @@ L:RegisterTranslations("enUS", function() return {
 	bar_drawSpiritStun = "Stun",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Lethon",
+
+	tailsweep_cmd = "tailsweep",
+    tailsweep_name = "龙尾扫击警报",
+    tailsweep_desc = "龙尾扫击出现时进行警告",
+	
+	dreamfog_cmd = "dreamfog",
+    dreamfog_name = "梦境迷雾昏睡警报",
+    dreamfog_desc = "梦境迷雾昏睡出现时进行警告",
+	
+	noxiousbreath_cmd = "noxiousbreath",
+    noxiousbreath_name = "毒性吐息警报",
+    noxiousbreath_desc = "毒性吐息出现时进行警告",
+	
+	shadowbolt_cmd = "shadowbolt",
+    shadowbolt_name = "暗影箭警报",
+    shadowbolt_desc = "暗影箭出现时进行警告",
+	
+	summon_cmd = "summon",
+    summon_name = "召唤警报",
+    summon_desc = "召唤出现时进行警告",
+
+
+	trigger_engage = "I can sense the SHADOW on your hearts. There can be no rest for the wicked!", --CHAT_MSG_MONSTER_YELL
+	
+	--self
+	trigger_tailSweepYou = "Tail Sweep hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_tailSweepYou = "龙尾扫击 - 不要站在龙的后面！",
+	
+	--self
+	trigger_dreamFogYou = "You are afflicted by Sleep.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_dreamFogYouFade = "Sleep fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_dreamFogYou = "梦境迷雾昏睡 - 不要站在梦境迷雾之中！",
+
+	--if nox you, for loop, find bossTarget, if bossTarget not you then WarningSign + msg only tank should
+	trigger_noxiousBreathYou = "You are afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathOther = "(.+) is afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_noxiousBreathCd = "毒性吐息 CD",
+    msg_noxiousBreathYou = "毒性吐息 - 不要站在龙的前面！",
+
+	--if is 3+ then bar
+	trigger_noxiousBreathStackYou = "You are afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathStackOther = "(.+) is afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_noxiousBreathFade = "Noxious Breath fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_noxiousBreath = " 毒性吐息",
+	
+	--trigger_shadowBoltYou = "Lethon's Shadow Bolt Whirl hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	--trigger_shadowBoltOther = "Lethon's Shadow Bolt Whirl hits (.+) for", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_shadowBoltGain = "Lethon gains Shadow Bolt Whirl.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_shadowBolt = "暗影箭 ",
+    msg_shadowBoltSwapSide = "暗影箭换边 - 转动雷索！",
+	
+	trigger_summon = "Your wicked souls shall feed my power!", --CHAT_MSG_MONSTER_YELL
+    msg_summon = "灵魂之影 - 击杀小怪！",
+    msg_summonSoon = "小怪即将出现",
+	
+	trigger_drawSpiritStun = "afflicted by Draw Spirit.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_drawSpiritStun = "眩晕",
+    you = "you",
+} end )
 local timer = {
 	dreamFog = 5,
 	

--- a/Raids/Other/NerubianOverseer.lua
+++ b/Raids/Other/NerubianOverseer.lua
@@ -75,6 +75,74 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "NerubianOverseer",
+
+	shadowshock_cmd = "shadowshock",
+    shadowshock_name = "暗影震击警报",
+    shadowshock_desc = "暗影震击出现时进行警告",
+
+    venomspit_cmd = "venomspit",
+    venomspit_name = "毒液喷吐警报",
+    venomspit_desc = "毒液喷吐出现时进行警告",
+    
+    poisoncloud_cmd = "poisoncloud",
+    poisoncloud_name = "毒云警报",
+    poisoncloud_desc = "毒云出现时进行警告",
+    
+    corrosivepoison_cmd = "corrosivepoison",
+    corrosivepoison_name = "腐蚀毒药警报",
+    corrosivepoison_desc = "腐蚀毒药出现时进行警告",
+    
+    necroticpoison_cmd = "necroticpoison",
+    necroticpoison_name = "死灵之毒警报",
+    necroticpoison_desc = "死灵之毒出现时进行警告",
+    
+    webspray_cmd = "webspray",
+    webspray_name = "蛛网喷射警报",
+    webspray_desc = "蛛网喷射出现时进行警告",
+    
+    explode_cmd = "explode",
+    explode_name = "爆炸警报",
+    explode_desc = "爆炸出现时进行警告",
+	
+	
+		--750 shadow damage, 10sec CD
+	trigger_shadowShock = "Nerubian Overseer's Shadow Shock hits",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_shadowShock = "暗影震击",
+	
+		--poison dot, 30sec flat
+	trigger_venomSpit = "afflicted by Venom Spit",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_venomSpit = "毒液喷吐",
+
+	trigger_poisonCloud = "You are afflicted by Poison Cloud.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_poisonCloudFade = "Poison Cloud fades from you.",--CHAT_MSG_SPELL_AURA_GONE_SELF
+
+		-- -5k armor, 700dmg/5sec 30sec, poison
+	trigger_corrosivePoison = "(.+) is afflicted by Corrosive Poison.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_corrosivePoisonYou = "You are afflicted by Corrosive Poison.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_corrosivePoisonFade = "Corrosive Poison fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_corrosivePoison = "腐蚀毒药",
+	
+		-- -90% healing, 30sec, happens on anyone, often, only warn if on tank
+	trigger_necroticPoison = "(.+) is afflicted by Necrotic Poison.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_necroticPoisonYou = "You are afflicted by Necrotic Poison.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_necroticPoisonFade = "Necrotic Poison fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_necroticPoison = "死灵之毒",
+	
+	trigger_webSpray = "(.+) is afflicted by Web Spray.",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_webSprayYou = "You are afflicted by Web Spray.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_webSprayCd = "下一次蛛网喷射",
+    bar_webSprayAfflic = "蛛网喷射",
+	
+	trigger_explode = "(.+) explodes.",--CHAT_MSG_RAID_BOSS_EMOTE
+	trigger_explodeYou = "You explode.",--CHAT_MSG_RAID_BOSS_EMOTE
+    msg_explode = " 爆炸了，诞生了4个小蛛魔！",
+    you = "you",
+} end )
 local timer = {
 	shadowShock = 10,
 	venomSpit = 30,

--- a/Raids/Other/Ostarius.lua
+++ b/Raids/Other/Ostarius.lua
@@ -158,6 +158,157 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Ostarius",
+
+    conflagbar_cmd = "conflagbar",
+    conflagbar_name = "燃烧计时",
+    conflagbar_desc = "燃烧技能的计时条",
+
+    conflagyou_cmd = "conflagyou",
+    conflagyou_name = "燃烧伤害警告",
+    conflagyou_desc = "燃烧造成伤害时进行警告",
+
+    chainlightning_cmd = "chainlightning",
+    chainlightning_name = "闪电链警报",
+    chainlightning_desc = "闪电链出现时进行警告",
+
+    blizzard_cmd = "blizzard",
+    blizzard_name = "暴风雪警告",
+    blizzard_desc = "暴风雪出现时进行警告",
+
+    rainoffire_cmd = "rainoffire",
+    rainoffire_name = "火焰之雨警告",
+    rainoffire_desc = "火焰之雨出现时进行警告",
+
+    sonicburst_cmd = "sonicburst",
+    sonicburst_name = "音爆警告",
+    sonicburst_desc = "音爆出现时进行警告",
+
+    activation_cmd = "activation",
+    activation_name = "激活计时",
+    activation_desc = "Boss激活的计时器",
+
+    phase_cmd = "phase",
+    phase_name = "阶段警告",
+    phase_desc = "阶段出现变化时进行警告",
+
+    portals_cmd = "portals",
+    portals_name = "传送门警报",
+    portals_desc = "传送门出现时进行警告",
+
+    traps_cmd = "traps",
+    traps_name = "陷阱警告",
+    traps_desc = "陷阱阶段开始/结束时进行警告",
+
+    eq_cmd = "eq",
+    eq_name = "地震警告",
+    eq_desc = "地震出现时进行警告",
+	
+    stomp_cmd = "stomp",
+    stomp_name = "坦克践踏警报",
+    stomp_desc = "坦克被践踏时进行警告",
+	
+		--using self only because affects many people within the same second
+	trigger_conflagYou = "You are afflicted by Conflagration.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    say_conflagYou = "我中了燃烧！快跑开！",
+    bar_conflag = " 燃烧",
+	trigger_conflagYouFade = "Conflagration fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_conflagHitYou = "'s Conflagration hits you for", --CHAT_MSG_SPELL_SELF_DAMAGE
+    msg_conflagHitYou = "远离燃烧效果！",
+	
+	trigger_chainLightning = "Ostarius's Chain Lightning",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_chainLightning = "下一次闪电链",
+	
+	trigger_blizzardPhase = "Elusive... Then face the might of the frost!", --CHAT_MSG_MONSTER_YELL
+    msg_blizzardPhase = "不再施放火焰之雨 - 现在施放暴风雪！",
+	trigger_blizzardYou = "You are afflicted by Blizzard.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_blizzardYou = "远离暴风雪区域！",
+	trigger_blizzardYouFade = "Blizzard fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_rainOfFirePhase = "Fire will burn your corruption!", --CHAT_MSG_MONSTER_YELL
+    msg_rainOfFirePhase = "现在施放火焰之雨！",
+	trigger_rainOfFireYou = "You are afflicted by Rain of Fire.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_rainOfFireYou = "远离火焰之雨区域！",
+	trigger_rainOfFireYouFade = "Rain of Fire fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_sonicBurstYou = "You are afflicted by Sonic Burst.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_sonicBurstYou = "音爆影响范围为20码...",
+	
+	
+    bar_activeX = "奥兹塔里亚斯 激活",
+	trigger_active33 = "Welcome, honored guests, to the research facility.", --CHAT_MSG_MONSTER_YELL
+    msg_active33 = "奥兹塔里亚斯 33秒后激活！",
+	
+	trigger_active27 = "Please wait for the initial scanning...", --CHAT_MSG_MONSTER_YELL
+    msg_active27 = "奥兹塔里亚斯 27秒后激活！",
+	
+	trigger_active17 = "WARNING! Curse of the flesh detected!", --CHAT_MSG_MONSTER_YELL
+    msg_active17 = "奥兹塔里亚斯 17秒后激活！",
+	
+	trigger_active13 = "Initiating manual gate override... Gate locked successfully.",--CHAT_MSG_MONSTER_YELL
+    msg_active13 = "奥兹塔里亚斯 13秒后激活！",
+	
+	trigger_active6 = "Activating defensive system for threat elimination.", --CHAT_MSG_MONSTER_YELL
+    msg_active6 = "奥兹塔里亚斯 6秒后激活！",
+	
+	trigger_activeNow = "Guardians, awaken and smite these intruders!", --CHAT_MSG_MONSTER_YELL
+    msg_activeNow = "奥兹塔里亚斯 已激活！",
+	
+    bar_portals = "下一次传送门",
+    msg_portals = "传送门！",
+	
+	trigger_engage = "Ostarius gains Defensive Storm.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	
+	
+	--unused
+		--p1 only, from adds, blue beam, stunnable, may cause clutter if warning this + conflag
+	trigger_mortalityScan = "You are afflicted by Mortality Scan.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_mortalityScanFade = "Mortality Scan fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	--unused
+		--p2 only, from traps and pillars, better to stand in this than other ability, so may not want to warn about
+	trigger_frostBreath = "You are afflicted by Frost Breath.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_frostBreathFade = "Frost Breath fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+
+	--p3 only, 30-28%, 20-18%, 10-8%
+	trigger_earthquake = "'s Earthquake", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    msg_earthquakeSoon = "地震即将来临！近战退后！",
+    msg_earthquakeDone = "地震结束！近战输出！",
+	
+	trigger_stomp = "(.+) is afflicted by Stomp.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_stompYou = "You are afflicted by Stomp.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_stompFade = "Stomp fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_stomp = " 被践踏",
+	
+	--is there a yell for all phases?
+	--is p2 or p3 the slow part?
+    msg_phase2 = "第二阶段 - 范围伤害技能",
+    msg_phase3 = "第三阶段 -- 不再施放暴风雪 -- 缓慢输出...",
+    msg_phase4 = "第四阶段 - 击败Boss！",
+    msg_traps = "启动陷阱！看见就解除！",
+    msg_trapsFade = "陷阱阶段结束！",
+		
+	trigger_p3 = "Still you persist, servants of the old ones? Very well.", --CHAT_MSG_MONSTER_YELL
+	trigger_p4 = "NO! I will not fail again!", --CHAT_MSG_MONSTER_YELL
+	
+	--[[
+	Frost Breath?
+	Mortality Scan, 11sec, channel, casted by Ostarius or not? Overlaps many. Kickable?
+	
+	Stomp?
+	Harsh Winds?
+	
+	Chain Lightning, interruptible? Happenned 3x, at 15sec interval
+	The yells?
+	Gate Construct, there is 8, do they spawn at the same time?
+	]]--
+	you = "you",
+} end )
 local timer = {
 	active33 = 33,
 	active27 = 27,

--- a/Raids/Other/Taerar.lua
+++ b/Raids/Other/Taerar.lua
@@ -84,6 +84,81 @@ L:RegisterTranslations("enUS", function() return {
 	msg_poisonCloud = "Move away from the Poison Cloud!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Taerar",
+
+	tailsweep_cmd = "tailsweep",
+    tailsweep_name = "龙尾扫击警报",
+    tailsweep_desc = "龙尾扫击出现时进行警告",
+	
+	dreamfog_cmd = "dreamfog",
+    dreamfog_name = "梦境迷雾昏睡警报",
+    dreamfog_desc = "梦境迷雾昏睡出现时进行警告",
+	
+	noxiousbreath_cmd = "noxiousbreath",
+    noxiousbreath_name = "毒性吐息警报",
+    noxiousbreath_desc = "毒性吐息出现时进行警告",
+	
+	fear_cmd = "fear",
+    fear_name = "恐惧警报",
+    fear_desc = "恐惧出现时进行警告",
+	
+	arcaneblast_cmd = "arcaneblast",
+    arcaneblast_name = "奥术冲击警报",
+    arcaneblast_desc = "奥术冲击出现时进行警告",
+	
+	summon_cmd = "summon",
+    summon_name = "召唤警报",
+    summon_desc = "召唤出现时进行警告",
+	
+	poisoncloud_cmd = "poisoncloud",
+    poisoncloud_name = "毒性云雾警报",
+    poisoncloud_desc = "毒性云雾出现时进行警告",
+
+
+	trigger_engage = "Peace is but a fleeting dream! Let the NIGHTMARE reign!", --CHAT_MSG_MONSTER_YELL
+	
+	--self
+	trigger_tailSweepYou = "Tail Sweep hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_tailSweepYou = "龙尾扫击 - 不要站在龙的后面！",
+	
+	--self
+	trigger_dreamFogYou = "You are afflicted by Sleep.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_dreamFogYouFade = "Sleep fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_dreamFogYou = "梦境迷雾昏睡 - 不要站在梦境迷雾之中！",
+
+	--if nox you, for loop, find bossTarget, if bossTarget not you then WarningSign + msg only tank should
+	trigger_noxiousBreathYou = "You are afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathOther = "(.+) is afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_noxiousBreathCd = "毒性吐息 CD",
+    msg_noxiousBreathYou = "毒性吐息 - 不要站在龙的前面！",
+
+	--if is 3+ then bar
+	trigger_noxiousBreathStackYou = "You are afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathStackOther = "(.+) is afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_noxiousBreathFade = "Noxious Breath fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_noxiousBreath = " 毒性吐息",
+	
+	trigger_fear = "Taerar begins to cast Bellowing Roar.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_fearCast = "恐惧！",
+    bar_fearCd = "恐惧 CD",
+	
+	trigger_arcaneBast = "Taerar's Arcane Blast", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_arcaneBlast = "奥术冲击 CD",
+	
+	trigger_summon = "Children of Madness - I release you upon this world!", --CHAT_MSG_MONSTER_YELL
+    msg_summon = "3个泰拉尔之影 - 击杀小怪！",
+    msg_summonSoon = "小怪即将出现",
+    msg_shadeDead = "/3 泰拉尔之影死亡",
+	
+	trigger_poisonCloud = "You are afflicted by Poison Cloud.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_poisonCloudFade = "Poison Cloud fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_poisonCloud = "远离毒云！",
+    you = "you",
+} end )
 local timer = {
 	dreamFog = 5,
 	

--- a/Raids/Other/TwilightCorrupter.lua
+++ b/Raids/Other/TwilightCorrupter.lua
@@ -42,6 +42,43 @@ L:RegisterTranslations("enUS", function() return {
 	subStringDead = "(.+) dies.",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "TwilightCorrupter",
+
+	creatureofnightmare_cmd = "creatureofnightmare",
+    creatureofnightmare_name = "精神控制警报",
+    creatureofnightmare_desc = "精神控制出现时进行警告",
+
+	soulcorruption_cmd = "soulcorruption",
+    soulcorruption_name = "灵魂腐蚀警报",
+    soulcorruption_desc = "灵魂腐蚀出现时进行警告",
+	
+	swellofsouls_cmd = "swellofsouls",
+    swellofsouls_name = "死亡增加攻击力警报",
+    swellofsouls_desc = "当前死亡增加攻击力时进行警告",
+	
+	
+		--MC, 1 person, 30sec duration, then 8sec CD
+	trigger_creatureOfNightmare = "(.+) is afflicted by Creature of Nightmare.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_creatureOfNightmareYou = "You are afflicted by Creature of Nightmare.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_creatureOfNightmareFade = "Creature of Nightmare fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY //CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_creatureOfNightmareAfflic = " 精神控制",
+    bar_creatureOfNightmareCd = "精神控制 CD",
+	
+		--AoE, 40yd, 15sec DoT + knockback, cd is min20 max30sec
+	trigger_soulCorruption = "afflicted by Soul Corruption.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_soulCorruptionCd = "灵魂腐蚀 CD",
+    bar_soulCorruptionSoon = "灵魂腐蚀 即将到来...",
+	
+    bar_swellOfSouls = " 攻击力增益",
+	
+    subStringDead = "(.+) dies.",
+    clickme = " >点击我！<",
+    you = "you",
+} end )
 local timer = {
 	creatureOfNightmareAfflic = 30,
 	creatureOfNightmareCd = 8,

--- a/Raids/Other/Ysondre.lua
+++ b/Raids/Other/Ysondre.lua
@@ -91,6 +91,88 @@ L:RegisterTranslations("enUS", function() return {
 	msg_silence = " Silenced - Dispel!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Ysondre",
+
+    tailsweep_cmd = "tailsweep",
+    tailsweep_name = "龙尾扫击警报",
+    tailsweep_desc = "龙尾扫击出现时进行警告",
+
+    dreamfog_cmd = "dreamfog",
+    dreamfog_name = "梦境迷雾昏睡警报",
+    dreamfog_desc = "梦境迷雾昏睡出现时进行警告",
+
+    noxiousbreath_cmd = "noxiousbreath",
+    noxiousbreath_name = "毒性吐息警报",
+    noxiousbreath_desc = "毒性吐息出现时进行警告",
+
+    lightningwave_cmd = "lightningwave",
+    lightningwave_name = "闪电波警报",
+    lightningwave_desc = "闪电波出现时进行警告",
+
+    summon_cmd = "summon",
+    summon_name = "召唤警报",
+    summon_desc = "召唤出现时进行警告",
+
+    curseofthorns_cmd = "curseofthorns",
+    curseofthorns_name = "荆棘诅咒警报",
+    curseofthorns_desc = "荆棘诅咒出现时进行警告",
+
+    silence_cmd = "silence",
+    silence_name = "沉默警报",
+    silence_desc = "沉默出现时进行警告",
+
+
+	trigger_engage = "The strands of LIFE have been severed! The Dreamers must be avenged!", --CHAT_MSG_MONSTER_YELL
+	
+	--self
+	trigger_tailSweepYou = "Tail Sweep hits you for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_tailSweepYou = "龙尾扫击 - 不要站在龙的后面！",
+	
+	--self
+	trigger_dreamFogYou = "You are afflicted by Sleep.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_dreamFogYouFade = "Sleep fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_dreamFogYou = "梦境迷雾昏睡 - 不要站在梦境迷雾之中！",
+
+	--if nox you, for loop, find bossTarget, if bossTarget not you then WarningSign + msg only tank should
+	trigger_noxiousBreathYou = "You are afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathOther = "(.+) is afflicted by Noxious Breath", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_noxiousBreathCd = "毒性吐息 CD",
+    msg_noxiousBreathYou = "毒性吐息 - 不要站在龙的前面！",
+
+	--if is 3+ then bar
+	trigger_noxiousBreathStackYou = "You are afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_noxiousBreathStackOther = "(.+) is afflicted by Noxious Breath %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_noxiousBreathFade = "Noxious Breath fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_noxiousBreath = " 毒性吐息",
+	
+	trigger_lightningWave = "Ysondre's Lightning Wave hits", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_lightningWave = "闪电波 CD",
+	
+	--Come forth, ye Dreamers â€“ and claim your vengeance!
+		--WTF are those weird chars?
+	trigger_summon = "Come forth, you Dreamers - and claim your vengeance!", --CHAT_MSG_MONSTER_YELL
+	trigger_summon2 = "Come forth, ye Dreamers", --CHAT_MSG_MONSTER_YELL
+    msg_summon = "狂乱的德鲁伊之魂 - 击杀小怪！",
+    msg_summonSoon = "小怪即将出现",
+	
+	
+	trigger_curseOfThornsYou = "You are afflicted by Curse of Thorns.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_curseOfThornsOther = "(.+) is afflicted by Curse of Thorns.",  --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE //CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_curseOfThornsFade = "Curse of Thorns fades from (.+).",  --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_curseOfThorns = " 荆棘",
+    msg_curseOfThorns = " 荆棘之咒 - 驱散诅咒！",
+	
+	trigger_silenceYou = "You are afflicted by Silence.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_silenceOther = "(.+)  is afflicted by Silence.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_silenceFade = "Silence fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_silence = " 沉默",
+    msg_silence = " 沉默 - 驱散！",
+    you = "you",
+} end )
 local timer = {
 	dreamFog = 5,
 	

--- a/Raids/UBRS/Beast.lua
+++ b/Raids/UBRS/Beast.lua
@@ -20,6 +20,20 @@ L:RegisterTranslations("enUS", function() return {
 	bar_fearCd = "Fear CD",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Beast",
+
+    fear_cmd = "fear",
+    fear_name = "恐惧",
+    fear_desc = "恐惧冷却计时器。",
+    
+    trigger_fear = "afflicted by Terrifying Roar.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_fearDuration = "恐惧持续时间",
+    bar_fearCd = "恐惧冷却",
+} end )
 local timer = {
 	fearCd = 10,
 	fearDuration = 5,

--- a/Raids/UBRS/Drakkisath.lua
+++ b/Raids/UBRS/Drakkisath.lua
@@ -54,6 +54,48 @@ L:RegisterTranslations("enUS", function() return {
 	msg_bringBossBack = "Adds are dead, bring Drakkisath back!",
 } end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Drakkisath",
+
+    flamestrike_cmd = "flamestrike",
+    flamestrike_name = "烈焰风暴警报",
+    flamestrike_desc = "当站在烈焰风暴范围时进行警告",
+
+    conflag_cmd = "conflag",
+    conflag_name = "燃烧警报",
+    conflag_desc = "燃烧出现时进行警告",
+
+    conflagproxy_cmd = "conflagproxy",
+    conflagproxy_name = "附近燃烧伤害警报",
+    conflagproxy_desc = "对附近友方造成的燃烧伤害进行警告",
+
+    adds_cmd = "adds",
+    adds_name = "已死亡增援计数",
+    adds_desc = "通报死亡的多彩精英卫兵数量",
+
+
+
+    trigger_conflagSelf = "You are afflicted by Conflagration.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_conflagOther = "(.+) is afflicted by Conflagration.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_conflagFade = "Conflagration fades from (.+).",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_Other
+    bar_conflag = " 燃烧",
+    msg_conflag = " 燃烧",
+
+    trigger_flamestrike = "You are afflicted by Flamestrike.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_flamestrikeFade = "Flamestrike fades from you.",--CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_flamestrike = "从烈焰风暴中离开！",
+
+    trigger_conflagProxy = "Conflagration hits you for",--CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+    msg_conflagProxy = "远离附近燃烧的人，你这个傻瓜！！！",
+
+    msg_addDead = "/2 增援死亡",
+    msg_bringBossBack = "增援死了，把达基萨斯拉回来！",
+    generaldrakkisathdies = "达基萨斯将军已死。",
+    you = "you",
+} end)
 local timer = {
 	conflag = 10,
 }

--- a/Raids/UBRS/Emberseer.lua
+++ b/Raids/UBRS/Emberseer.lua
@@ -28,6 +28,25 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_bossDead = "Pyroguard Emberseer dies.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Emberseer",
+
+	firenova_cmd = "firenova",
+    firenova_name = "火焰新星计时器",
+    firenova_desc = "显示下一次火焰新星的剩余时间。",
+
+	trigger_engage = "Ha! Ha! Ha! Thank you for freeing me, fools. Now let me repay you by charring the flesh from your bones.",--CHAT_MSG_MONSTER_SAY
+
+	trigger_firenova = "Fire Nova",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_firenova = "火焰新星",
+	
+    msg_addDead = "/7 监禁者死亡",
+	
+	trigger_bossDead = "Pyroguard Emberseer dies.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+} end )
 local timer = {
 	firenova = 6,
 }

--- a/Raids/UBRS/Rend.lua
+++ b/Raids/UBRS/Rend.lua
@@ -98,6 +98,79 @@ local rendDead = nil
 local gythDead = nil
 local bwPlayerIsAttacking = nil
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Gyth",
+	
+	flamebreath_cmd = "flamebreath",
+    flamebreath_name = "烈焰吐息",
+    flamebreath_desc = "烈焰吐息出现时进行警告",
+	
+	freeze_cmd = "freeze",
+    freeze_name = "冰冻",
+    freeze_desc = "提示团队驱散你的冰冻效果。",
+	
+	dismount_cmd = "dismount",
+    dismount_name = "下马",
+    dismount_desc = "当雷德下马时进行警告",
+	
+	whirlwind_cmd = "whirlwind",
+    whirlwind_name = "旋风斩",
+    whirlwind_desc = "雷德旋风斩的计时器。",
+	
+	enrage_cmd = "enrage",
+    enrage_name = "激怒",
+    enrage_desc = "激怒提示。",
+	
+	waves_cmd = "waves",
+    waves_name = "波次",
+    waves_desc = "波次警告。",
+	
+	
+	
+	trigger_flamebreath = "Gyth begins to cast Flame Breath.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_flamebreathCd = "烈焰吐息冷却",
+    bar_flamebreathCast = "烈焰吐息",
+	
+	trigger_freezeYou = "You are afflicted by Freeze.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_freezeOther = "(.+) is afflicted by Freeze.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    msg_freeze = "驱散冰冻！",
+	
+	trigger_dismount = "Gyth casts Summon Rend Blackhand.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_dismount = "雷德已经下马！",
+	
+	trigger_whirlwind = "Warchief Rend Blackhand gains Whirlwind.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_whirlwindCd = "旋风斩冷却",
+    bar_whirlwindCast = "旋风斩！",
+	
+	trigger_enrage = "Warchief Rend Blackhand gains Enrage.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS",
+    msg_enrage = "雷德激怒了！",
+	
+	trigger_engage = "Excellent... it would appear as if the meddlesome insects have arrived just in time to feed my legion. Welcome, mortals!",--CHAT_MSG_MONSTER_YELL
+	trigger_bossNext = "THIS CANNOT BE!!! Rend, deal with these insects.",--CHAT_MSG_MONSTER_YELL
+	
+    bar_beforeWave1 = "波次开始",
+    bar_beforeWave2 = "波次 2/7 开始",
+    bar_beforeWave3 = "波次 3/7 开始",
+    bar_beforeWave4 = "波次 4/7 开始",
+    bar_beforeWave5 = "波次 5/7 开始",
+    bar_beforeWave6 = "波次 6/7 开始",
+    bar_beforeWave7 = "波次 7/7 开始",
+    bar_beforeWaveBoss = "Gyth",
+
+    bar_waves1 = "波次 1/7",
+    bar_waves2 = "波次 2/7",
+    bar_waves3 = "波次 3/7",
+    bar_waves4 = "波次 4/7",
+    bar_waves5 = "波次 5/7",
+    bar_waves6 = "波次 6/7",
+    bar_waves7 = "波次 7/7 - 下一个是Boss！",
+    c_chromaticwhelp = "多彩雏龙",
+    c_chromaticdragonspawn = "多彩龙人",
+    c_blackhanddragonhandler = "黑手驭龙者",
+} end )
 local timer = {
 	beforeWave1 = 13.5,
 	beforeWave2 = 40,

--- a/Raids/UBRS/Solakar.lua
+++ b/Raids/UBRS/Solakar.lua
@@ -46,6 +46,44 @@ L:RegisterTranslations("enUS", function() return {
 	msg_bossSpawn = "Solakar spawned!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Solakar",
+	
+	waves_cmd = "waves",
+    waves_name = "波次",
+    waves_desc = "波次警告。",
+	
+	warstomp_cmd = "warstomp",
+    warstomp_name = "战争践踏",
+    warstomp_desc = "战争践踏出现时进行警告",
+		
+	trigger_warstomp = "Solakar Flamewreath's War Stomp",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_warstomp = "眩晕！",
+	
+	trigger_engage = "Intruders are destroying our eggs!  Stop!!",--CHAT_MSG_MONSTER_YELL
+	
+    msg_wave1 = "波次 1/5 -- 2 孵化者 / 守护者",
+    bar_timeToWave2 = "波次 2/5 出现",
+	
+    msg_wave2 = "波次 2/5 -- 2 孵化者 / 守护者",
+    bar_timeToWave3 = "波次 3/5 出现",
+	
+    msg_wave3 = "波次 3/5 -- 2 孵化者 / 守护者",
+    bar_timeToWave4 = "波次 4/5 出现",
+	
+    msg_wave4 = "波次 4/5 -- 2 孵化者 / 守护者",
+    bar_timeToWave5 = "波次 5/5 出现",
+	
+    msg_wave5 = "波次 5/5 -- 2 孵化者 / 守护者",
+    bar_timeToBoss = "索拉卡·火冠出现",
+	
+	trigger_bossSpawn = "I am here! Now, puny little worms, you will pay for your intrusion!",--CHAT_MSG_MONSTER_YELL
+    msg_bossSpawn = "索拉卡·火冠出现了！",
+    z_nightmareillusion = "孵化间",
+} end )
 local timer = {
 	timeToWave2 = 40,--need more data
 	timeToWave3 = 40,--80sec from start

--- a/Raids/ZG/Arlokk.lua
+++ b/Raids/ZG/Arlokk.lua
@@ -69,6 +69,74 @@ L:RegisterTranslations("enUS", function() return {
 	msg_swp = " Shadow Word: Pain - Dispel!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Arlokk",
+	
+	phase_cmd = "phase",
+    phase_name = "阶段变化警报",
+    phase_desc = "阶段变化时进行警告",
+	
+	mark_cmd = "mark",
+    mark_name = "娅尔罗的印记警报",
+    mark_desc = "娅尔罗的印记出现时进行警告",
+
+	whirlwind_cmd = "whirlwind",
+    whirlwind_name = "旋风斩警报",
+    whirlwind_desc = "旋风斩出现时进行警告",
+
+	ravage_cmd = "ravage",
+    ravage_name = "毁灭警报",
+    ravage_desc = "毁灭出现时进行警告",
+
+	gouge_cmd = "gouge",
+    gouge_name = "凿击警报",
+    gouge_desc = "凿击出现时进行警告",
+	
+	swp_cmd = "swp",
+    swp_name = "暗言术：痛警报",
+    swp_desc = "暗言术：痛出现时进行警告",
+	
+	
+	trigger_engage = "贝泰克，你的女祭司召唤你的力量！",--CHAT_MSG_MONSTER_YELL
+	
+    msg_trollPhase = "巨魔阶段 - 施放凿击和暗言术：痛", --supposed to cast gouge in troll form only, is it the case on twow?
+    msg_pantherPhase = "豹形阶段 - 伤害增加35% - 施放背刺和毁灭",
+    msg_vanishPhase = "消失阶段 - 施放娅尔罗的印记",
+    bar_return = "重新出现冷却",
+    bar_returnSoon = "即将重新出现...",
+    bar_nextVanish = "下一次消失",
+    bar_nestTroll = "下一次巨魔阶段", --need data on timer
+	
+	trigger_markYou = "你受到了娅尔罗的印记效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_markOther = "(.+)受到了娅尔罗的印记效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_markFade = "娅尔罗的印记效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_mark = " 被标记！",
+    bar_mark = " 标记",
+	
+	trigger_ww = "高阶女祭司娅尔罗的旋风斩",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    bar_ww = "旋风斩冷却",
+	
+	trigger_ravageYou = "你受到了毁灭效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_ravageOther = "(.+)受到了毁灭效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_ravageFade = "毁灭效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_ravage = " 毁灭昏迷",
+	
+	trigger_gougeYou = "You are afflicted by Gouge.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_gougeOther = "(.+) is afflicted by Gouge.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_gougeFade = "Gouge fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_gouge = " 被凿击",
+	
+	trigger_swpYou = "你受到了暗言术：痛效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_swpOther = "(.+)受到了暗言术：痛效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_swpFade = "暗言术：痛效果从(.+)身上消失了。",	--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_swp = " 暗言术：痛",
+    msg_swp = " 暗言术：痛 - 驱散！",
+    you = "你",
+    clickme = " >点击我<",
+} end )
 local timer = {
 	firstVanish = 35,
 	vanish = 75,

--- a/Raids/ZG/Gahzranka.lua
+++ b/Raids/ZG/Gahzranka.lua
@@ -71,6 +71,40 @@ L:RegisterTranslations("deDE", function() return {
 	massivegeyser_desc = "Warnen wenn Gahz'ranka beginnt Massiver Geysir zu wirken.",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Gahzranka",
+
+    frostbreath_cmd = "frostbreath",
+    frostbreath_name = "冰霜吐息警报",
+    frostbreath_desc = "当Boss开始施放冰霜吐息时进行警告",
+
+    geyser_cmd = "geyser",
+    geyser_name = "巨型喷泉警报",
+    geyser_desc = "当Boss开始施放巨型喷泉时进行警告",
+
+    slam_cmd = "slam",
+    slam_name = "猛击警报",
+    slam_desc = "当Boss施放猛击时进行警告",
+
+    trigger_frostbreathCast = "Gahz'ranka begins to perform Frost Breath.",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_frostbreathCast = "冰霜吐息伤害+法力燃烧",
+    msg_frostbreathCast = "冰霜吐息，伤害 + 法力燃烧",
+    bar_frostbreathCd = "冰霜吐息冷却",
+    trigger_frostbreathYou = "Frost Breath hits you",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_frostBreathYou = "你被冰霜吐息法力燃烧了！",
+
+    trigger_geyserBegin = "Gahz'ranka begins to cast Massive Geyser.",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_geyserCast = "击飞 - 仇恨减少",
+    msg_geyserCast = "击飞 - 仇恨减少",
+    trigger_geyserCast = "Gahz'ranka casts Massive Geyser.",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_geyserCd = "击飞仇恨减少冷却",
+
+    trigger_slam = "Gahz'ranka Slam",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_slam = "击退 -冷却",
+} end )
 local timer = {
 	frostbreathCast = 2,
 	frostbreathCd = 7,--9 -2sec for cast = 7 (need more data)

--- a/Raids/ZG/Grilek.lua
+++ b/Raids/ZG/Grilek.lua
@@ -60,6 +60,64 @@ L:RegisterTranslations("enUS", function() return {
 	bar_sweepingStrikes = "Sweeping Strikes!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Grilek",
+	
+    avatar_cmd = "avatar",
+    avatar_name = "天神下凡警报",
+    avatar_desc = "天神下凡出现时进行警告。",
+
+    puticon_cmd = "puticon",
+    puticon_name = "在格里雷克的目标上放置图标",
+    puticon_desc = "在格里雷克的目标玩家身上标记团队图标。",
+
+    stun_cmd = "stun",
+    stun_name = "首领昏迷警报",
+    stun_desc = "格里雷克在天神下凡后昏迷（2秒）时警告。",
+
+    groundtremor_cmd = "groundtremor",
+    groundtremor_name = "地震警报",
+    groundtremor_desc = "地震出现时进行警告。",
+	
+    roots_cmd = "roots",
+    roots_name = "纠缠根须警报",
+    roots_desc = "纠缠根须出现时进行警告。",
+
+    sweepingstrikes_cmd = "sweepingstrikes",
+    sweepingstrikes_name = "横扫攻击警报",
+    sweepingstrikes_desc = "横扫攻击出现时进行警告。",
+
+
+    trigger_avatar = "Gri'lek is afflicted by Avatar.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    trigger_avatarFade = "Avatar fades from Gri'lek.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_avatarCd = "天神下凡 CD",
+    bar_avatarDur = "天神下凡！",
+    msg_avatar = "天神下凡 - 远离Boss！",
+	
+    trigger_stun = "Gri'lek is afflicted by Stun.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    trigger_stunFade = "Stun fades from Gri'lek.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_stun = "格里雷克昏迷",
+
+    trigger_groundTremor = "afflicted by Ground Tremor.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_groundTremorFade = "Ground Tremor fades from", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_groundTremorCd = "地震 CD",
+    bar_groundTremorDur = "地震昏迷",
+
+    trigger_rootsYou = "You are afflicted by Entangling Roots.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    trigger_rootsOther = "(.+) is afflicted by Entangling Roots.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    trigger_rootsFade = "Entangling Roots fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_roots = " 纠缠",
+	
+	--untested
+    trigger_sweepingStrikes = "Gri'lek gains Sweeping Strikes.", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    trigger_sweepingStrikes2 = "Gri'lek is afflicted Sweeping Strikes.", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+    trigger_sweepingStrikesFade = "Sweeping Strikes fades from Gri'lek.", --guessing CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_sweepingStrikes = "横扫攻击！",
+    you = "you",
+} end )
 local timer = {
 	firstAvatar = 25,
 	avatarCd = 10, --25s - duration

--- a/Raids/ZG/GurubashiBatRider.lua
+++ b/Raids/ZG/GurubashiBatRider.lua
@@ -29,6 +29,27 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "BatRider",
+
+    bars_cmd = "bars",
+    bars_name = "显示计时条开关",
+    bars_desc = "切换是否显示计时条。",
+
+    bigicon_cmd = "bigicon",
+    bigicon_name = "大图标警告",
+    bigicon_desc = "爆炸时的大图标警告",
+
+    explodingTrigger = "Gurubashi Bat Rider gets a crazed look in his eye.",
+    explodingTrigger2 = "Gurubashi Bat Rider becomes fully engulfed in flames.",
+    explodingBar = "即将爆炸",
+    explodingMsg = "即将爆炸！",
+
+    ["You have slain %s!"] = "你已经击败了%s！",
+} end )
 local timer = {
 	exploding = 3,
 }

--- a/Raids/ZG/GurubashiBerserker.lua
+++ b/Raids/ZG/GurubashiBerserker.lua
@@ -39,7 +39,36 @@ L:RegisterTranslations("enUS", function() return {
 } end )
 
 
-
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Berserker",
+	
+	fear_cmd = "fear",
+	fear_name = "恐惧警报",
+	fear_desc = "恐惧出现时进行警告",
+	
+	knock_cmd = "knock",
+	knock_name = "击退警报",
+	knock_desc = "击退出现时进行警告",
+	
+	thunderclap_cmd = "thunderclap",
+	thunderclap_name = "雷霆一击警报",
+	thunderclap_desc = "雷霆一击出现时进行警告",
+	
+	
+	
+	trigger_fear1 = "afflicted by Intimidating Roar",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_fear2 = "Intimidating Roar fail(.+) immune.",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_fear3 = "Intimidating Roar was resisted",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_fear = "恐惧 CD",
+	
+	trigger_knockAway = "Gurubashi Berserker's Knock Away",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_knockAway = "击退 CD",
+	
+	trigger_thunderclap = "Gurubashi Berserker's Thunderclap",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_thunderclap = "雷霆一击 CD",
+} end )
 local timer = {
 	firstFear = 15,--ok
 	fear = 25,--ok

--- a/Raids/ZG/Hakkar.lua
+++ b/Raids/ZG/Hakkar.lua
@@ -110,6 +110,111 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Hakkar",
+
+	mc_cmd = "mc",
+    mc_name = "心控警报",
+    mc_desc = "心控出现时进行警告",
+
+	siphon_cmd = "siphon",
+    siphon_name = "吸血警报",
+    siphon_desc = "吸血出现时进行警告",
+
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告",
+
+	aspectjeklik_cmd = "aspectjeklik",
+    aspectjeklik_name = "耶克里克变形警报",
+    aspectjeklik_desc = "耶克里克变形出现时进行警告",
+
+	aspectvenoxis_cmd = "aspectvenoxis",
+    aspectvenoxis_name = "温诺希斯变形警报",
+    aspectvenoxis_desc = "温诺希斯变形出现时进行警告",
+
+	aspectmarli_cmd = "aspectmarli",
+    aspectmarli_name = "玛尔里变形警报",
+    aspectmarli_desc = "玛尔里变形出现时进行警告",
+
+	aspectthekal_cmd = "aspectthekal",
+    aspectthekal_name = "塞卡尔变形警报",
+    aspectthekal_desc = "塞卡尔变形出现时进行警告",
+
+	aspectarlokk_cmd = "aspectarlokk",
+    aspectarlokk_name = "娅尔罗变形警报",
+    aspectarlokk_desc = "娅尔罗变形出现时进行警告",
+	
+	
+	trigger_engage = "骄傲预示着你的世界的终结。来吧，凡人！面对夺魂者的愤怒！", --CHAT_MSG_MONSTER_YELL
+	
+	trigger_enrage = "面对夺魂者的愤怒！", --to be confirmed
+    bar_enrage = "狂暴",
+    msg_enrage = "哈卡狂暴了！",
+    msg_enrage60 = "1分钟后狂暴！",
+    msg_enrage10 = "10秒后狂暴！",
+	
+	trigger_causeInsanityYou = "你受到了疯狂效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_causeInsanityOther = "(.+)受到了疯狂效果的影响。", --CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_causeInsanityFade = "疯狂效果从(.+)身上消失。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	trigger_causeInsanityTotem = "哈卡的疯狂施放失败。根基图腾对此免疫。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
+    msg_causeInsanity = "心控",
+    bar_causeInsanity = "心控",
+    bar_causeInsanityCd = "心控冷却",
+	
+	trigger_bloodSiphon = "哈卡获得了血液虹吸的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_bloodSiphon30 = "30秒后吸血！",
+    bar_bloodSiphonDur = "吸血！",
+    bar_bloodSiphonCd = "下一次吸血",
+	
+	--unreliable, as if someone dies this will trigger
+	--trigger_bloodSiphonFade = "Blood Siphon fades from Hakkar.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	
+	trigger_poisonousBloodYou = "你受到了酸性血液效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_poisonousBloodOther = "(.+)受到了酸性血液效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE //CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_poisonousBloodFade = "酸性血液效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_poisonousBlood = " 毒血",
+	
+	--1.5k dmg + silence 5sec, 45yard
+	trigger_aspectOfJeklik = "受到了耶克里克的守护效果的影响。", --guessing CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE //CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_aspectOfJeklikResist = "哈卡的耶克里克的守护", --guessing ???
+    bar_aspectOfJeklikCd = "沉默冷却 - 耶克里克",
+    bar_aspectOfJeklikDur = "沉默！ - 耶克里克",
+	
+	--30yard, poison volley, 10sec dot, 438dmg + 236 per 2sec, 1.6k dmg total
+	trigger_aspectOfVenoxis = "哈卡的温诺希斯的守护击中", --guessing ???
+	trigger_aspectOfVenoxisResist = "哈卡的温诺希斯的守护被", --guessing ???
+    bar_aspectOfVenoxisCd = "毒性冷却 - 温诺希斯",
+	
+	--6sec stun, single target
+	trigger_aspectOfMarliYou = "你受到了玛尔里的守护效果的影响。", --guessing CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_aspectOfMarliOther = "(.+)受到了玛尔里的守护效果的影响。", --guessing CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE //CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_aspectOfMarliResist = "哈卡的玛尔里的守护", --guessing ???
+	trigger_aspectOfMarliFade = "玛尔里的守护效果从(.+)身上消失了。", --guessing CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_aspectOfMarliCd = "昏迷冷却 - 玛尔里",
+    bar_aspectOfMarliDur = "昏迷 - 玛尔里",
+	
+	--frenzy, 150% attack speed
+	trigger_aspectOfThekal = "哈卡获得了塞卡尔的守护的效果。", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_aspectOfThekalFade = "塞卡尔的守护效果从哈卡身上消失。", --guessing CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_aspectOfThekalCd = "狂暴冷却 - 塞卡尔",
+    bar_aspectOfThekalDur = "狂暴！ - 塞卡尔",
+    msg_aspectOfThekal = "狂暴 - 宁神射击！",
+
+	--2sec stun, single target
+	trigger_aspectOfArlokkYou = "You are afflicted by Aspect of Arlokk.", --guessing CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_aspectOfArlokkOther = "(.+) is afflicted by Aspect of Arlokk.", --guessing CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE //CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_aspectOfArlokkResist = "Hakkar's Aspect of Arlokk", --guessing ???
+	trigger_aspectOfArlokkFade = "Aspect of Arlokk fades from (.+).", --guessing CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_aspectOfArlokkCd = "哈卡隐身冷却 - 娅尔罗",
+    bar_aspectOfArlokkDur = "隐身 - 娅尔罗",
+    c_sonofhakkar = "哈卡之子",
+    you = "你",
+    clickme = " >点击我<",
+} end)
 local timer = {
 	causeInsanityFirstCd = 17,
 	causeInsanityDur = 10,

--- a/Raids/ZG/Hazzarah.lua
+++ b/Raids/ZG/Hazzarah.lua
@@ -37,6 +37,41 @@ L:RegisterTranslations("enUS", function() return {
 	msg_chainBurn = "AoE Mana Burn - Drain his Mana!",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Hazzarah",
+	
+    adds_cmd = "adds",
+    adds_name = "梦魇幻象增援警报",
+    adds_desc = "梦魇幻象增援出现时进行警告",
+
+    sleep_cmd = "sleep",
+    sleep_name = "沉睡警报",
+    sleep_desc = "沉睡效果出现时进行警告",
+
+    chainburn_cmd = "chainburn",
+    chainburn_name = "法力燃烧链警报",
+    chainburn_desc = "法力燃烧链效果出现时进行警告",
+
+
+    trigger_addsSpawn = "Hazza'rah casts Summon Nightmare Illusions.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_adds = "增援出现",
+    bar_addsCounter = "增援死亡",
+    msg_addsSpawn = "3个梦魇幻象 - 远程，击杀增援！",
+
+    trigger_sleep = "afflicted by Sleep", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_sleepCd = "沉睡 冷却",
+    bar_sleepAfflic = "沉睡中！",
+    msg_sleep = "沉睡 - 施放战栗图腾！",
+
+    --did not see, wild guessing
+    trigger_chainBurn = "Chain Burn hit", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_chainBurn = "AoE法力燃烧 CD",
+    msg_chainBurn = "AoE法力燃烧 - 抽干他的法力！",
+    c_nightmareillusion = "梦魇幻象",
+} end )
 local timer = {
 	firstAdds = 21,
 	adds = 24,

--- a/Raids/ZG/Jeklik.lua
+++ b/Raids/ZG/Jeklik.lua
@@ -91,6 +91,94 @@ L:RegisterTranslations("enUS", function() return {
 	msg_p2 = "Phase 2",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Jeklik",
+
+	heal_cmd = "heal",
+    heal_name = "治疗警报",
+    heal_desc = "治疗时进行警告",
+	
+	fear_cmd = "fear",
+    fear_name = "恐惧警报",
+    fear_desc = "恐惧出现时进行警告",
+	
+	fire_cmd = "fire",
+    fire_name = "火蝠警报",
+    fire_desc = "站在火中的警告",
+	
+	mindflay_cmd = "mindflay",
+    mindflay_name = "精神鞭笞警报",
+    mindflay_desc = "施放精神鞭笞时进行警告",
+
+	silence_cmd = "silence",
+    silence_name = "沉默警报",
+    silence_desc = "沉默时进行警告",
+
+	swarm_cmd = "swarm",
+    swarm_name = "蝙蝠群警报",
+    swarm_desc = "蝙蝠群出现时进行警告",
+	
+	phase_cmd = "phase",
+    phase_name = "阶段通知",
+    phase_desc = "Boss阶段转换时进行警告",
+	
+	
+	trigger_engage = "Lord Hir'eek, grant me wings of vengance!",--CHAT_MSG_MONSTER_YELL
+	
+	trigger_heal = "High Priestess Jeklik begins to cast Great Heal.",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF",
+    bar_healCast = "治疗 - 打断！",
+    bar_healCd = "治疗冷却",
+    msg_healCast = "治疗！打断它！",
+	
+	trigger_attack1 = "High Priestess Jeklik attacks", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack2 = "High Priestess Jeklik misses", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack3 = "High Priestess Jeklik hits", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_attack4 = "High Priestess Jeklik crits", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_kick1 = "Kick hits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick2 = "Kick crits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick3 = "Kick was blocked by High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel1 = "Pummel hits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel2 = "Pummel crits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel3 = "Pummel was blocked by High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash1 = "Shield Bash hits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash2 = "Shield Bash crits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash3 = "Shield Bash was blocked by High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock1 = "Earth Shock hits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock2 = "Earth Shock crits High Priestess Jeklik", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	
+	--this happens in P1
+	trigger_terrifyingScreech1 = "afflicted by Terrifying Screech",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_terrifyingScreech2 = "Terrifying Screech was resisted",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_terrifyingScreech3 = "Terrifying Screech fail",--TBD
+	
+	--guessing this happens in P2
+	trigger_psychicScream1 = "afflicted by Psychic Scream",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_psychicScream2 = "Psychic Scream was resisted",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_psychicScream3 = "Psychic Scream fail",--TBD
+
+    bar_fearCd = "恐惧冷却",
+	
+	trigger_liquidFire = "Liquid Fire hits you for",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+    msg_liquidFire = "远离火焰！",
+	
+	trigger_mindflay = "afflicted by Mind Flay",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE //CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+		--mindflay chains, this trigger is unreliable
+	--trigger_mindflayFade = "Mind Flay fades",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mindflay = "精神鞭笞 - 打断！",
+	
+	trigger_silence = "Sonic Burst hits",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_silenceAfflicted = "被沉默",
+    bar_silenceCd = "沉默冷却",
+	
+	trigger_swarm = "TBD",--TBD, is there a trigger or it's on a fixed timer?
+    bar_swam = "蝙蝠群",
+    msg_swarm = "蝙蝠群！AOE！",
+	
+    msg_p2 = "第二阶段",
+} end )
 local timer = {
 	healCast = 4,
 	healCd = 20,--need data

--- a/Raids/ZG/Jindo.lua
+++ b/Raids/ZG/Jindo.lua
@@ -59,6 +59,58 @@ L:RegisterTranslations("enUS", function()
 	}
 end)
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Jindo",
+	
+	curse_cmd = "curse",
+    curse_name = "诅咒警报",
+    curse_desc = "当玩家受到金度的欺骗时进行警告。",
+
+	hex_cmd = "hex",
+    hex_name = "妖术警报",
+    hex_desc = "当玩家受到妖术时进行警告。",
+	
+	brainwash_cmd = "brainwash",
+    brainwash_name = "洗脑图腾警报",
+    brainwash_desc = "当金度召唤洗脑图腾时进行警告。",
+
+	healingward_cmd = "healingward",
+    healingward_name = "治疗图腾警报",
+    healingward_desc = "当金度召唤强力治疗图腾时进行警告。",
+
+	autotarget_cmd = "autotarget",
+    autotarget_name = "自动标记图腾",
+    autotarget_desc = "自动标记图腾",
+	
+	
+	trigger_engage = "朋友，欢迎参加这场盛宴。来吧，狂欢至死吧！",--CHAT_MSG_MONSTER_YELL
+	
+	trigger_hexYou = "你受到了妖术效果的影响。",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	trigger_hexOther = "(.+)受到了妖术效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_hexFade = "妖术效果从(.+)身上消失了。",----CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+    bar_hex = " 妖术",
+    msg_hex = " 被妖术 - 驱散！",
+	
+	trigger_curseYou = "你受到了金度的欺骗效果的影响。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    msg_curseYou = "你被诅咒了！转火影子！",
+	trigger_curseOther = "(.+)受到了金度的欺骗效果的影响。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_curse = " 被诅咒",
+	trigger_curseFade = "金度的欺骗效果从(.+)身上消失了。",--CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
+	
+	trigger_curseDispel = "金度的欺骗被移除了。",--CHAT_MSG_SPELL_BREAK_AURA
+    msg_curseDispel = "金度的欺骗被驱散了！",
+	
+	trigger_brainWash = "妖术师金度施放了召唤洗脑图腾。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_brainWash = "快打洗脑图腾！",
+	--trigger_brainWashDeath = "Brain Wash Totem is destroyed.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+	
+	trigger_healingWard = "妖术师金度施放了强力治疗结界。",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_healingWard = "快打治疗图腾！",
+	--trigger_healingWardDeath = "Powerful Healing Ward is destroyed.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+} end )
 local timer = {
 	hexDuration = 5,
 	curseDuration = 20,

--- a/Raids/ZG/MadServant.lua
+++ b/Raids/ZG/MadServant.lua
@@ -26,6 +26,20 @@ module.defaultDB = {
 	bosskill = nil,
 }
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "madservant",
+
+    portal_cmd = "portal",
+    portal_name = "传送门警报",
+    portal_desc = "疯狂之门出现警告。",
+
+    trigger_portal = "Mad Servant casts Portal of Madness.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    bar_portal = "虚空产生 - 传送门 ",
+    msg_portal = "如果你想保命，那就暂缓击杀其他小鬼！",
+} end )
 local timer = {
 	portal = 11,
 }

--- a/Raids/ZG/Mandokir.lua
+++ b/Raids/ZG/Mandokir.lua
@@ -69,6 +69,72 @@ L:RegisterTranslations("enUS", function() return {
 	msg_levelUp = "Mandokir Leveled Up by killing someone - He is now Level "
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Mandokir",
+	
+	gaze_cmd = "gaze",
+    gaze_name = "威慑凝视警报",
+    gaze_desc = "威慑凝视时进行警告",
+	
+	cancelaction_cmd = "cancelaction",
+    cancelaction_name = "威慑凝视时自动取消所有动作",
+    cancelaction_desc = "当你受到威慑凝视时自动取消所有动作",
+	
+	whirlwind_cmd = "whirlwind",
+    whirlwind_name = "旋风斩警报",
+    whirlwind_desc = "旋风斩时进行警告",
+	
+	charge_cmd = "charge",
+    charge_name = "冲锋警报",
+    charge_desc = "冲锋时进行警告",
+	
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒时进行警告",
+	
+	sunder_cmd = "sunder",
+    sunder_name = "破甲警报",
+    sunder_desc = "破甲时进行警告",
+	
+	levelup_cmd = "levelup",
+    levelup_name = "升级警报",
+    levelup_desc = "升级时进行警告",
+	
+	
+	trigger_engage = "我会把你们的灵魂喂给哈卡本人！", --CHAT_MSG_MONSTER_YELL
+	
+	trigger_gaze = "(.+)！我在看着你！", --CHAT_MSG_MONSTER_YELL
+	trigger_gazeFade = "威慑凝视效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_gazeCd = "威慑凝视冷却",
+    bar_gazeDur = " 凝视！",
+    msg_gaze = "威慑凝视 - 停止所有动作",
+	
+	trigger_whirlwind = "血领主曼多基尔获得了旋风斩的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    bar_whirlwindCd = "旋风斩冷却",
+    bar_whirlwindCast = "施放旋风斩！",
+	
+	trigger_charge = "血领主曼多基尔的冲锋击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_chargeCd = "冲锋冷却",
+	
+	
+	trigger_enrage = "血领主曼多基尔获得了激怒的效果。", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_enrageFade = "激怒效果从血领主曼多基尔身上消失。", --guessing CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_enrage = "你杀死了奥根 - 血领主曼多基尔激怒了！",
+    msg_enrageFade = "血领主曼多基尔不再激怒！",
+	
+	trigger_sunderYou = "你受到了破甲效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_sunderOther = "(.+)受到了破甲效果的影响%（(.+)%）。",--CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+    bar_sunder = " 破甲",
+    msg_sunderHigh = " 破甲层数高 - 换坦！",
+	
+	trigger_levelUp = "叮！", --CHAT_MSG_MONSTER_YELL
+    msg_levelUp = "血领主曼多基尔通过杀人升级 - 他现在是等级 ",
+    c_ohgan = "奥根",
+    you = "你",
+} end )
 local timer = {
 	gazeFirstCd = 33,
 	gazeCd = 12,

--- a/Raids/ZG/Marli.lua
+++ b/Raids/ZG/Marli.lua
@@ -66,6 +66,69 @@ L:RegisterTranslations("enUS", function() return {
 	bar_poisonVolleyCd = "Poison Volley CD",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Marli",
+	
+	webs_cmd = "webs",
+    webs_name = "包围之网警报",
+    webs_desc = "包围之网时进行警告",
+	
+	charge_cmd = "charge",
+    charge_name = "冲锋警报",
+    charge_desc = "冲锋时进行警告",
+	
+	drain_cmd = "drain",
+    drain_name = "吸取生命警报",
+    drain_desc = "吸取生命时进行警告",
+	
+	phase_cmd = "phase",
+    phase_name = "阶段变化警报",
+    phase_desc = "阶段变化时进行警告",
+	
+	spider_cmd = "spider",
+    spider_name = "蜘蛛增援警报",
+    spider_desc = "蜘蛛增援时进行警告",
+
+	volley_cmd = "volley",
+    volley_name = "毒箭之雨警报",
+    volley_desc = "毒箭之雨时进行警告",
+	
+	
+	trigger_engage = "Draw me to your web mistress Shadra. Unleash your venom!",--CHAT_MSG_MONSTER_YELL
+	trigger_bossDead = "High Priestess Mar'li dies.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+	--trigger_addDead = "Spawn of Mar'li dies.",--CHAT_MSG_COMBAT_HOSTILE_DEATH
+	
+	trigger_websOther = "(.+) is afflicted by Enveloping Webs.", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
+	trigger_websYou = "You are afflicted by Enveloping Webs.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+    bar_websCd = "包围之网冷却",
+	
+	trigger_charge = "High Priestess Mar'li's Charge",--CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_chargeCd = "冲锋冷却",
+	
+	--if registering CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE then will Warlock's...
+	trigger_drainLifeOther = "(.+) is afflicted by Drain Life.",--CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_drainLifeYou = "You are afflicted by Drain Life.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_drainLifeFade = "Drain Life fades from (.+)",--CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_drainLife = "吸取生命",
+    msg_drainLife = "吸取生命 - 打断/驱散！",
+	
+	trigger_spiderPhase = "Shadra, make of me your avatar!",--CHAT_MSG_MONSTER_YELL
+    bar_spiderPhaseTimer = "下一次巨魔阶段",
+	
+	--no trigger for Troll Phase
+    bar_trollPhaseTimer = "下一次蜘蛛阶段",
+	
+	--no trigger for adds spawn
+    bar_addsCd = "蜘蛛增援刷新",
+    msg_addsDead = "/4 蜘蛛已死",
+    msg_spidersSpawn = "杀死蜘蛛增援！",
+	
+	trigger_poisonVolley = "afflicted by Poison Bolt Volley.",--CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+    bar_poisonVolleyCd = "毒箭之雨冷却",
+} end )
 local timer = {
 	websFirstCd = 5,
 	websCd = {10,20},--saw 11,19 

--- a/Raids/ZG/Renataki.lua
+++ b/Raids/ZG/Renataki.lua
@@ -36,6 +36,39 @@ L:RegisterTranslations("enUS", function() return {
 	bar_gouge = "Gouge CD",	
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Renataki",
+
+    vanish_cmd = "vanish",
+    vanish_name = "消失/返回警报",
+    vanish_desc = "消失和返回出现时进行警告。",
+
+    enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒出现时进行警告。",
+
+    gouge_cmd = "gouge",
+    gouge_name = "凿击警报",
+    gouge_desc = "凿击出现时进行警告。",
+    
+    
+    --no trigger for vanish
+    msg_vanish = "雷纳塔基已经消失了！",
+    bar_nextReturn = "返回",
+	
+	trigger_vanishFade = "Unknown's Ambush", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    msg_vanishFade = "雷纳塔基出现了！",
+    bar_nextVanish = "消失",
+	
+	trigger_enrage = "Renataki gains Enrage.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "激怒！",
+	
+	trigger_gouge = "Renataki's Gouge", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_gouge = "凿击 CD",
+} end )
 local timer = {
 	nextVanish = 28,
 	nextReturn = 20,

--- a/Raids/ZG/Thekal.lua
+++ b/Raids/ZG/Thekal.lua
@@ -171,6 +171,158 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_bossDead = "Hakkar binds me no more! Peace at last!", --CHAT_MSG_MONSTER_YELL
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Thekal",
+	
+	heal_cmd = "heal",
+    heal_name = "强效治疗警报",
+    heal_desc = "狂热者洛卡恩施放强效治疗时进行警告",
+	
+	silence_cmd = "silence",
+    silence_name = "沉默警报",
+    silence_desc = "沉默时进行警告",
+	
+	disarm_cmd = "disarm",
+    disarm_name = "缴械警报",
+    disarm_desc = "缴械时进行警告",
+	
+	blind_cmd = "blind",
+    blind_name = "致盲警报",
+    blind_desc = "致盲时进行警告",
+	
+	gouge_cmd = "gouge",
+    gouge_name = "凿击警报",
+    gouge_desc = "凿击时进行警告",
+	
+	mortalcleave_cmd = "mortalcleave",
+    mortalcleave_name = "致死顺劈警报",
+    mortalcleave_desc = "致死顺劈时进行警告",
+	
+	bloodlust_cmd = "bloodlust",
+    bloodlust_name = "嗜血警报",
+    bloodlust_desc = "嗜血时进行警告",
+
+	punch_cmd = "punch",
+    punch_name = "重击警报",
+    punch_desc = "重击时进行警告",
+
+	charge_cmd = "charge",
+    charge_name = "冲锋警报",
+    charge_desc = "冲锋时进行警告",
+	
+	frenzy_cmd = "frenzy",
+    frenzy_name = "狂暴警报",
+    frenzy_desc = "狂暴时进行警告",
+
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒时进行警告",
+	
+	adds_cmd = "adds",
+    adds_name = "猛虎增援警报",
+    adds_desc = "猛虎增援时进行警告",
+	
+	hpbars_cmd = "hpbars",
+    hpbars_name = "第一阶段的血量条",
+    hpbars_desc = "显示塞卡尔、札斯和洛卡恩的血量条",
+	
+	reztimer_cmd = "reztimer",
+    reztimer_name = "复活计时器",
+    reztimer_desc = "计时死亡后复活的时间",
+	
+	
+	trigger_heal = "狂热者洛卡恩开始施放强力治疗术。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+    msg_heal = "狂热者洛卡恩正在治疗 - 打断！",
+    bar_heal = "治疗施法中",
+	
+	trigger_attack1 = "狂热者洛卡恩攻击", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack2 = "狂热者洛卡恩没有击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_MISSES // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_MISSES
+	trigger_attack3 = "狂热者洛卡恩击中", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_attack4 = "狂热者洛卡恩的致命一击对", --CHAT_MSG_COMBAT_CREATURE_VS_SELF_HITS // CHAT_MSG_COMBAT_CREATURE_VS_PARTY_HITS // CHAT_MSG_COMBAT_CREATURE_VS_CREATURE_HITS
+	trigger_kick1 = "脚踢击中狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick2 = "脚踢对狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_kick3 = "脚踢被狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel1 = "拳击击中狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel2 = "拳击对狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_pummel3 = "拳击被狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash1 = "盾击击中狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash2 = "盾击对狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_shieldBash3 = "盾击被狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock1 = "地震术击中狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	trigger_earthShock2 = "地震术致命一击对狂热者洛卡恩", --CHAT_MSG_SPELL_SELF_DAMAGE // CHAT_MSG_SPELL_PARTY_DAMAGE // CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_HOSTILEPLAYER_DAMAGE
+	
+	trigger_silenceYou = "你受到了沉默效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_silenceOther = "(.+)受到了沉默效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_silenceFade = "沉默效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_silence = " 被沉默",
+    msg_silence = " 沉默 - 驱散！",
+	
+	trigger_disarmYou = "你受到了缴械效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_disarmOther = "(.+)受到了缴械效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_disarmFade = "缴械效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_disarm = " 被缴械",
+	
+	trigger_blindYou = "你受到了致盲效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_blindOther = "(.+)受到了致盲效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_blindFade = "致盲效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_blind = " 被致盲",
+	
+	trigger_gougeYou = "你受到了凿击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_gougeOther = "(.+)受到了凿击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_gougeFade = "凿击效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_gouge = " 被凿击",
+	
+	trigger_mortalCleaveYou = "你受到了致死顺劈效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_mortalCleaveOther = "(.+)受到了致死顺劈效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_mortalCleaveFade = "致死顺劈效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_mortalCleave = " 致死顺劈",
+	
+	--to be confirmed
+	trigger_bloodlustGain = "(.+)获得了嗜血的效果。", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_bloodlustFade = "嗜血效果从(.+)身上消失了。", --guessing CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_bloodlust = " 嗜血",
+    msg_bloodlust = " 嗜血 - 驱散！",
+	
+		--unuseable due to %s
+	--trigger_mobDies = "(.+) dies.", --CHAT_MSG_MONSTER_EMOTE --High Priest Thekal // Zealot Zath // Zealot Lor'Khan
+    bar_rezTimer = "复活",
+	
+	trigger_resurrection = "被附近的盟友复活了!", --CHAT_MSG_MONSTER_EMOTE --High Priest Thekal // Zealot Zath // Zealot Lor'Khan
+	
+	trigger_phase2 = "Shirvallah，让我充满你的愤怒！", --CHAT_MSG_MONSTER_YELL
+	
+    bar_phase2 = "猛虎阶段",
+    msg_phase2 = "第二阶段 - 猛虎阶段",
+	
+	trigger_forcePunch = "古拉巴什食腐者的重击击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_forcePunch = "重击冷却",
+    bar_forcePunchCast = "施放重击！",
+	
+	trigger_charge = "受到了冲锋效果的影响。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_charge = "冲锋冷却",
+	
+	--to be confirmed
+	trigger_frenzyGain = "High Priest Thekal gains Frenzy.", --guessing CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_frenzyFade = "Frenzy fades from High Priest Thekal.", --guessing, CHAT_MSG_SPELL_AURA_GONE_OTHER
+    msg_frenzy = "狂暴 - 宁神射击！",
+    bar_frenzy = "狂暴",
+	
+	trigger_enrage = "古拉巴什食腐者获得了狂怒的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "狂暴了！加大治疗！",
+	
+	--no trigger_tigers
+    bar_tigersCd = "猛虎生成冷却",
+    msg_tigers = "猛虎增援生成！",
+    msg_addDead = "/2 猛虎增援已死",
+	
+	trigger_bossDead = "哈卡不再束缚我！终于平安了！", --CHAT_MSG_MONSTER_YELL
+	c_zuliantiger = "祖利安猛虎",
+	c_zulianguardian = "祖利安守护者",
+	you ="你",
+} end )
 local timer = {
 	heal = 4,
 	silence = 6,

--- a/Raids/ZG/Venoxis.lua
+++ b/Raids/ZG/Venoxis.lua
@@ -90,6 +90,94 @@ L:RegisterTranslations("enUS", function() return {
 	msg_addDead = "/4 Snake Adds Dead",
 } end )
 
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Venoxis",
+
+	renew_cmd = "renew",
+    renew_name = "恢复警报",
+    renew_desc = "恢复时进行警告",
+
+	holyfire_cmd = "holyfire",
+    holyfire_name = "神圣之火警报",
+    holyfire_desc = "神圣之火时进行警告",
+	
+	holywrath_cmd = "holywrath",
+    holywrath_name = "神圣愤怒警报",
+    holywrath_desc = "神圣愤怒时进行警告",
+	
+	holynova_cmd = "holynova",
+    holynova_name = "神圣新星警报",
+    holynova_desc = "神圣新星时进行警告",
+	
+	phase_cmd = "phase",
+    phase_name = "阶段变化警报",
+    phase_desc = "蛇阶段时进行警告",
+	
+	poisoncloud_cmd = "poisoncloud",
+    poisoncloud_name = "毒云警报",
+    poisoncloud_desc = "毒云时进行警告",
+	
+	venomspit_cmd = "venomspit",
+    venomspit_name = "喷毒警报",
+    venomspit_desc = "喷毒时进行警告",
+	
+	enrage_cmd = "enrage",
+    enrage_name = "激怒警报",
+    enrage_desc = "激怒时进行警告",
+	
+	parasitic_cmd = "parasitic",
+    parasitic_name = "寄生蛇警报",
+    parasitic_desc = "寄生蛇时进行警告",
+	
+	adds_cmd = "adds",
+    adds_name = "增援死亡警报",
+    adds_desc = "增援死亡时进行警告",
+	
+	
+	trigger_renew = "High Priest Venoxis gains Renew.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_renewFade = "Renew fades from High Priest Venoxis.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_renew = "恢复",
+    msg_renew = "恢复 - 驱散！",
+	
+	trigger_holyFireCast = "High Priest Venoxis begins to cast Holy Fire.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_holyFireYou = "You are afflicted by Holy Fire.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_holyFireOther = "(.+) is afflicted by Holy Fire.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_holyFireFade = "Holy Fire fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_holyFireCast = "施放神圣之火！",
+    bar_holyFireDur = " 神圣之火",
+    msg_holyFire = "神圣之火 - 驱散！",
+	
+	trigger_holyWrath = "High Priest Venoxis's Holy Wrath", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_holyWrathCd = "神圣愤怒冷却",
+	
+	trigger_holyNova = "High Priest Venoxis's Holy Nova", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+    bar_holyNovaCd = "神圣新星冷却",
+	
+	trigger_phase2 = "Let the coils of hate unfurl!", --CHAT_MSG_MONSTER_YELL
+    msg_phase2 = "第二阶段 - 避免毒云！",
+	
+	trigger_poisonCloudYou = "You are afflicted by Poison Cloud.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_poisonCloudYouFade = "Poison Cloud fades from you.", --CHAT_MSG_SPELL_AURA_GONE_SELF
+    msg_poisonCloudYou = "远离毒云！",
+	
+	trigger_venomSpit = "High Priest Venoxis's Venom Spit hits (.+) for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_venomSpitFade = "Venom Spit fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+    bar_venomSpit = " 喷毒",
+	
+	trigger_enrage = "High Priest Venoxis gains Enrage.",--CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+    msg_enrage = "温诺希斯激怒了！",
+	
+	--no trigger for parasitic serpent, 1st at 11sec after p2, next is ???
+    bar_parasiticSerpent = "寄生蛇生成",
+    msg_parasiticSerpent = "杀死寄生蛇（低血量） - AoE！",
+	
+    msg_addDead = "/4 蛇增援已死",
+    c_razzashicobra = "拉扎什眼镜蛇",
+    you = "you",
+} end )
 local timer = {
 	renew = 15,
 	

--- a/Raids/ZG/Wushoolay.lua
+++ b/Raids/ZG/Wushoolay.lua
@@ -74,6 +74,26 @@ module.toggleoptions = {"chainlightning", "lightningcloud", "bosskill"}
 
 
 -- locals
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+    cmd = "Wushoolay",
+
+	chainlightning_trigger = "Wushoolay begins to cast Chain Lightning\.",
+    chainlightning_bar = "闪电链",
+    chainlightning_message = "闪电链！打断它！",
+	lightningcloud_trigger = "You are afflicted by Lightning Cloud\.",
+    lightningcloud_message = "离开闪电云！",
+
+	chainlightning_cmd = "chainlightning",
+    chainlightning_name = "闪电链警报",
+    chainlightning_desc = "当Boss施放闪电链时进行警告",
+
+	lightningcloud_cmd = "lightningcloud",
+    lightningcloud_name = "闪电云警告",
+    lightningcloud_desc = "当你站在闪电云中时进行警告",
+} end )
 local timer = {
 	chainlightning = 1.5,
 }


### PR DESCRIPTION
This PR adds `zhCN` localization coverage for raid modules and core/plugin UI text.

Scope:
- adds missing `zhCN` translation blocks to many raid modules
- adds `zhCN` translations for core UI and plugin UI text
- fixes a malformed `zhCN` translation block in `TwinGolems`

Notes:
- this PR is intended to be localization-only
- it does not add locale-specific sound behavior
- it does not intentionally change boss logic beyond enabling existing localized text paths
