### PR TITLE
Add zhCN localization for MC/BWL modules

### DIFF
--- a/Raids/BWL/Broodlord.lua
+++ b/Raids/BWL/Broodlord.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Broodlord Lashlayer", "Blackwing Lair")
+local bbbroodlordlashlayer = AceLibrary("Babble-Boss-2.2")["Broodlord Lashlayer"]
 
 module.revision = 30085
 module.enabletrigger = module.translatedName
@@ -45,6 +46,51 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_knock = "Broodlord Lashlayer's Knock Away", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
 	bar_knockCd = "Knock Away CD",
 	bar_knockSoon = "Knock Away Soon...",
+	you = "you",
+	} end )
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Broodlord",
+	
+	ms_cmd = "ms",
+	ms_name = "致死打击警报",
+	ms_desc = "致死打击出现时进行警告",
+
+	bw_cmd = "bw",
+	bw_name = "冲击波警报",
+	bw_desc = "冲击波出现时进行警告",
+
+	knock_cmd = "knock",
+	knock_name = "击飞警报",
+	knock_desc = "击飞出现时进行警告",
+
+	targeticon_cmd = "targeticon",
+	targeticon_name = "在BOSS的目标上标记骷髅",
+	targeticon_desc = "在BOSS的目标上标记骷髅团队图标",
+
+
+	trigger_engage = "你们这种人都不应该出现在这里！",
+	
+	trigger_msEvade = "勒什雷尔的致死打击被", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	msg_msEvade = "致死打击被闪避了！",
+
+	trigger_msYou = "你受到了致死打击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_msOther = "^(.+)(.+)致死打击效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_msFade = "致死打击效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_msCd = "致死打击冷却",
+	bar_msSoon = "即将致死打击...",
+	bar_msDur = " 致死打击",
+	msg_ms = " 致死打击",
+
+	trigger_bw = "^(.+)(.+)冲击波效果的影响。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_bwCd = "冲击波冷却",
+	bar_bwSoon = "即将冲击波...",
+
+	trigger_knock = "勒什雷尔的击退击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_knockCd = "击飞冷却",
+	bar_knockSoon = "即将击飞...",
+	you = "你",
 } end )
 
 local timer = {
@@ -137,7 +183,7 @@ end
 
 function module:BroodlordTarget()
 	if UnitName("Target") ~= nil and UnitName("TargetTarget") ~= nil and (IsRaidLeader() or IsRaidOfficer()) then
-		if UnitName("Target") == "Broodlord Lashlayer" then
+		if UnitName("Target") == bbbroodlordlashlayer then
 			SetRaidTarget("TargetTarget",8)
 		end
 	end
@@ -153,7 +199,7 @@ function module:Event(msg)
 	
 	elseif string.find(msg, L["trigger_msFade"]) then
 		local _,_,msFadePerson, _ = string.find(msg, L["trigger_msFade"])
-		if msFadePerson == "you" then msFadePerson = UnitName("Player") end
+		if msFadePerson == L["you"] then msFadePerson = UnitName("Player") end
 		self:Sync(syncName.msFade .. " "..msFadePerson)
 		
 	elseif string.find(msg, L["trigger_msEvade"]) then

--- a/Raids/BWL/Ebonroc.lua
+++ b/Raids/BWL/Ebonroc.lua
@@ -38,6 +38,45 @@ L:RegisterTranslations("enUS", function() return {
 	msg_shadowOfEbonroc = " has Shadow of Ebonroc - Taunt!",
 	bar_shadowOfEbonrocDur = " Shadow of Ebonroc",
 	bar_shadowOfEbonrocCd = "Shadow of Ebonroc CD",
+	you = "you",
+	} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Ebonroc",
+
+	wingbuffet_cmd = "wingbuffet",
+	wingbuffet_name = "龙翼打击警报",
+	wingbuffet_desc = "龙翼打击出现时进行警告",
+
+	shadowflame_cmd = "shadowflame",
+	shadowflame_name = "暗影烈焰警报",
+	shadowflame_desc = "暗影烈焰出现时进行警告",
+
+	curse_cmd = "curse",
+	curse_name = "埃博诺克之影警报",
+	curse_desc = "埃博诺克之影出现时进行警告",
+
+
+	trigger_wingBuffet = "埃博诺克开始施放龙翼打击。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_wingBuffetCast = "正在施放龙翼打击！",
+	bar_wingBuffetCd = "龙翼打击冷却",
+	msg_wingBuffetCast = "正在施放龙翼打击！",
+	msg_wingBuffetSoon = "2秒后龙翼打击 - 现在嘲讽！",
+
+	trigger_shadowFlame = "埃博诺克开始施放暗影烈焰。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_shadowFlameCast = "正在施放暗影烈焰！",
+	bar_shadowFlameCd = "暗影烈焰冷却",
+	msg_shadowFlameCast = "正在施放暗影烈焰！",
+
+	trigger_shadowOfEbonrocYou = "你受到了埃博诺克之影效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_shadowOfEbonrocOther = "(.+)受到了埃博诺克之影效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_shadowOfEbonrocFade = "埃博诺克之影效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	msg_shadowOfEbonroc = " 受到了埃博诺克之影 - 嘲讽！",
+	bar_shadowOfEbonrocDur = " 埃博诺克之影",
+	bar_shadowOfEbonrocCd = "埃博诺克之影冷却",
+	you = "你",
 } end)
 
 local timer = {
@@ -132,7 +171,7 @@ function module:Event(msg)
 		
 	elseif string.find(msg, L["trigger_shadowOfEbonrocFade"]) then
 		local _,_,shadowOfEbonrocFadePlayer,_ = string.find(msg, L["trigger_shadowOfEbonrocFade"])
-		if shadowOfEbonrocFadePlayer == "you" then shadowOfEbonrocFadePlayer = UnitName("Player") end
+		if shadowOfEbonrocFadePlayer == L["you"] then shadowOfEbonrocFadePlayer = UnitName("Player") end
 		self:Sync(syncName.shadowOfEbonrocFade .. " " .. shadowOfEbonrocFadePlayer)
 	end
 end

--- a/Raids/BWL/Firemaw.lua
+++ b/Raids/BWL/Firemaw.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Firemaw", "Blackwing Lair")
+local bbfiremaw = AceLibrary("Babble-Boss-2.2")["Firemaw"]
 
 module.revision = 30085
 module.enabletrigger = module.translatedName
@@ -47,6 +48,52 @@ L:RegisterTranslations("enUS", function() return {
 	
 	trigger_flameBuffetYou = "You are afflicted by Flame Buffet %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
 	msg_flameBuffetYou = " Flame Buffet Stacks - Consider losing your stacks",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Firemaw",
+
+	wingbuffet_cmd = "wingbuffet",
+	wingbuffet_name = "龙翼打击警报",
+	wingbuffet_desc = "龙翼打击出现时进行警告",
+
+	shadowflame_cmd = "shadowflame",
+	shadowflame_name = "暗影烈焰警报",
+	shadowflame_desc = "暗影烈焰出现时进行警告",
+
+	flamebuffet_cmd = "flamebuffet",
+	flamebuffet_name = "烈焰打击警报",
+	flamebuffet_desc = "烈焰打击出现时进行警告",
+
+	stacks_cmd = "stacks",
+	stacks_name = "烈焰打击层数过高警报",
+	stacks_desc = "烈焰打击层数过高时进行警告",
+
+
+	trigger_wingBuffet = "费尔默开始施放龙翼打击。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_wingBuffetCast = "正在施放龙翼打击！",
+	bar_wingBuffetCd = "龙翼打击冷却",
+	msg_wingBuffetCast = "正在施放龙翼打击！",
+	msg_wingBuffetSoon = "2秒后龙翼打击 - 现在嘲讽！",
+
+	trigger_shadowFlame = "费尔默开始施放暗影烈焰。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_shadowFlameCast = "正在施放暗影烈焰！",
+	bar_shadowFlameCd = "暗影烈焰冷却",
+	msg_shadowFlameCast = "正在施放暗影烈焰！",
+	
+	trigger_flameBuffet = "费尔默的烈焰打击", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+		--Firemaw's Flame Buffet fails. (.+) is immune.
+		--Firemaw's Flame Buffet was resisted by (.+).
+		--Firemaw's Flame Buffet was resisted.
+		--Firemaw's Flame Buffet hits (.+) for (.+) Fire damage.
+		--Firemaw's Flame Buffet is absorbed by (.+).
+		--You absorb Firemaw's Flame Buffet.
+	bar_flameBuffet = "烈焰打击",
+
+	trigger_flameBuffetYou = "你受到了烈焰打击效果的影响%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	msg_flameBuffetYou = " 烈焰打击层数 - 考虑清除你的层数",
 } end)
 
 local timer = {
@@ -173,7 +220,7 @@ end
 
 function module:FlameBuffetStacks(stacksNum)
 	--don't bother if you are tanking
-	if UnitName("Target") == "Firemaw" and UnitName("TargetTarget") == UnitName("Player") then return end
+	if UnitName("Target") == bbfiremaw and UnitName("TargetTarget") == UnitName("Player") then return end
 	
 	self:Message(stacksNum..L["msg_flameBuffetYou"], "Personal", false, nil, false)
 	self:WarningSign(icon.flameBuffet, 0.7)

--- a/Raids/BWL/Flamegor.lua
+++ b/Raids/BWL/Flamegor.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Flamegor", "Blackwing Lair")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30085
 module.enabletrigger = module.translatedName
@@ -37,6 +38,42 @@ L:RegisterTranslations("enUS", function() return {
 	bar_frenzyCd = "Frenzy CD",
 	bar_frenzyDur = "Frenzy!",
 	msg_frenzy = "Frenzy - Tranq now!",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Flamegor",
+
+	wingbuffet_cmd = "wingbuffet",
+	wingbuffet_name = "龙翼打击警报",
+	wingbuffet_desc = "龙翼打击出现时进行警告",
+
+	shadowflame_cmd = "shadowflame",
+	shadowflame_name = "暗影烈焰警报",
+	shadowflame_desc = "暗影烈焰出现时进行警告",
+
+	frenzy_cmd = "frenzy",
+	frenzy_name = "狂暴警报",
+	frenzy_desc = "狂暴出现时进行警告",
+	
+	
+	trigger_wingBuffet = "弗莱格尔开始施放龙翼打击。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_wingBuffetCast = "正在施放龙翼打击！",
+	bar_wingBuffetCd = "龙翼打击冷却",
+	msg_wingBuffetCast = "正在施放龙翼打击！",
+	msg_wingBuffetSoon = "2秒后龙翼打击 - 现在嘲讽！",
+
+	trigger_shadowFlame = "弗莱格尔开始施放暗影烈焰。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_shadowFlameCast = "正在施放暗影烈焰！",
+	bar_shadowFlameCd = "暗影烈焰冷却",
+	msg_shadowFlameCast = "正在施放暗影烈焰！",
+
+	trigger_frenzy = "弗莱格尔获得了疯狂的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_frenzyFade = "疯狂效果从弗莱格尔身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_frenzyCd = "狂暴冷却",
+	bar_frenzyDur = "狂暴！",
+	msg_frenzy = "狂暴 - 立即宁神！",
 } end)
 
 local timer = {
@@ -169,7 +206,7 @@ end
 function module:Frenzy()
 	self:RemoveBar(L["bar_frenzyCd"])
 	
-	if UnitClass("Player") == "Hunter" then
+	if UnitClass("Player") == BC["Hunter"] then
 		self:Message(L["msg_frenzy"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.tranquil, 1)

--- a/Raids/BWL/Vaelastrasz.lua
+++ b/Raids/BWL/Vaelastrasz.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Vaelastrasz the Corrupt", "Blackwing Lair")
+local bbvaelastraszthecorrupt = AceLibrary("Babble-Boss-2.2")["Vaelastrasz the Corrupt"]
 
 module.revision = 30085
 module.enabletrigger = module.translatedName
@@ -57,6 +58,7 @@ L:RegisterTranslations("enUS", function() return {
 	bar_adrenalineCd = "Burning Adrenaline CD",
 	bar_adrenalineDur = " Burning!",
 	msg_adrenaline = " has Burning Adrenaline",
+	msg_adrenalineSay = " has Burning Adrenaline!",
 	
 	trigger_dieYou = "You die.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
 	trigger_dieOther = "(.+) dies.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
@@ -78,6 +80,86 @@ L:RegisterTranslations("enUS", function() return {
 	
 	trigger_parryYou = "You attack. Vaelastrasz the Corrupt parries.", --CHAT_MSG_COMBAT_SELF_MISSES
 	msg_parryYou = "Vaelastrasz the Corrupt Parried your attack - Stop killing the tank you idiot!",
+	you = "you",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Vaelastrasz",
+	
+	start_cmd = "start",
+	start_name = "战斗警报",
+	start_desc = "战斗开始时进行警告",
+
+	adrenaline_cmd = "adrenaline",
+	adrenaline_name = "燃烧刺激警报",
+	adrenaline_desc = "燃烧刺激出现时进行警告",
+
+	icon_cmd = "icon",
+	icon_name = "燃烧刺激团队图标",
+	icon_desc = "在燃烧刺激目标上标记骷髅",
+
+	flamebreath_cmd = "flamebreath",
+	flamebreath_name = "火息术警报",
+	flamebreath_desc = "火息术出现时进行警告",
+
+	flamebreathdot_cmd = "flamebreathdot",
+	flamebreathdot_name = "火息术DoT警报",
+	flamebreathdot_desc = "火息术DoT出现时进行警告",
+
+	firenova_cmd = "firenova",
+	firenova_name = "火焰新星警报",
+	firenova_desc = "火焰新星出现时进行警告",
+
+	tailsweep_cmd = "tailsweep",
+	tailsweep_name = "龙尾扫击警报",
+	tailsweep_desc = "龙尾扫击出现时进行警告",
+
+	parry_cmd = "parry",
+	parry_name = "招架警报",
+	parry_desc = "招架出现时进行警告",
+	
+	
+	trigger_gossip1 = "太晚了，朋友们！奈法留斯的腐败已经蔓延", --CHAT_MSG_MONSTER_YELL
+	trigger_gossip2 = "我求求你们，凡人", --CHAT_MSG_MONSTER_YELL
+	trigger_gossip3 = "火焰！死亡！毁灭！", --CHAT_MSG_MONSTER_YELL
+	bar_gossip = "战斗开始",
+	msg_gossip = "瓦拉斯塔兹事件开始了！",
+	
+	trigger_engage = "受到了红龙精华效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	
+	--burning adrenaline on mana user every 15sec, every 45s on the tank ALSO
+		-- -5% hp per second
+	trigger_adrenalineYou = "你受到了燃烧刺激效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_adrenalineOther = "(.+)受到了燃烧刺激效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_adrenalineFade = "燃烧刺激效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER --guessing
+	bar_adrenalineCd = "燃烧刺激冷却",
+	bar_adrenalineDur = " 即将爆炸！",
+	msg_adrenaline = " 受到了燃烧刺激",
+	msg_adrenalineSay = " 中了燃烧刺激！",
+	
+	trigger_dieYou = "你死亡了。", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	trigger_dieOther = "(.+)死亡了。", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	
+	trigger_flameBreath = "堕落的瓦拉斯塔兹开始施放火息术。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_flameBreathCd = "火息术冷却",
+	bar_flameBreathCast = "正在施放火息术！",
+
+	trigger_flameBreathDotYou = "你受到了火息术效果的影响%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_flameBreathDotOther = "(.+)受到了火息术效果的影响%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_flameBreathDotFade = "火息术效果从(.+)身上消失了。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_flameBreathDot = " 火息术DoT",
+
+	trigger_fireNova = "堕落的瓦拉斯塔兹的火焰新星击中", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_fireNova = "火焰新星冷却",
+
+	trigger_tailSweepYou = "堕落的瓦拉斯塔兹的龙尾扫击击中你", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	msg_tailSweep = "龙尾扫击击中BOSS后方30码范围内。",
+
+	trigger_parryYou = "你发起了攻击。堕落的瓦拉斯塔兹招架住了。", --CHAT_MSG_COMBAT_SELF_MISSES
+	msg_parryYou = "堕落的瓦拉斯塔兹招架了你的攻击 - 别再害坦克了，笨蛋！",
+	you = "你",
 } end)
 
 local timer = {
@@ -239,7 +321,7 @@ function module:Event(msg)
 		
 	elseif string.find(msg, L["trigger_adrenalineFade"]) then
 		local _,_,adrenalineFadePlayer,_ = string.find(msg, L["trigger_adrenalineFade"])
-		if adrenalineFadePlayer == "you" then adrenalineFadePlayer = UnitName("Player") end
+		if adrenalineFadePlayer == L["you"] then adrenalineFadePlayer = UnitName("Player") end
 		self:Sync(syncName.adrenalinePlayerFade .. " " .. adrenalineFadePlayer)
 	
 	
@@ -264,7 +346,7 @@ function module:Event(msg)
 		
 	elseif string.find(msg, L["trigger_flameBreathDotFade"]) then
 		local _,_,flameBreathDotFadePlayer,_ = string.find(msg, L["trigger_flameBreathDotFade"])
-		if flameBreathDotFadePlayer == "you" then flameBreathDotFadePlayer = UnitName("Player") end
+		if flameBreathDotFadePlayer == L["you"] then flameBreathDotFadePlayer = UnitName("Player") end
 		self:Sync(syncName.flameBreathDotFade .. " " .. flameBreathDotFadePlayer)
 		
 		
@@ -276,7 +358,7 @@ function module:Event(msg)
 		
 	elseif string.find(msg, L["trigger_parryYou"]) and self.db.profile.parry then
 		if UnitName("Target") ~= nil and UnitName("TargetTarget") ~= nil then
-			if UnitName("Target") == "Vaelastrasz the Corrupt" and UnitName("TargetTarget") ~= UnitName("Player") then
+			if UnitName("Target") == bbvaelastraszthecorrupt and UnitName("TargetTarget") ~= UnitName("Player") then
 				self:ParryYou()
 			end
 		end
@@ -360,7 +442,7 @@ function module:AdrenalinePlayer(rest)
 		self:Message(rest..L["msg_adrenaline"], "Urgent", false, nil, false)
 		
 		if rest == UnitName("Player") then
-			SendChatMessage(UnitName("Player").." has Burning Adrenaline!","SAY")
+			SendChatMessage(UnitName("Player")..L["msg_adrenalineSay"],"SAY")
 			self:WarningSign(icon.adrenaline, 1)
 			self:Sound("RunAway")
 		end
@@ -368,7 +450,7 @@ function module:AdrenalinePlayer(rest)
 		if self.db.profile.icon and (IsRaidLeader() or IsRaidOfficer()) then
 			for i=1,GetNumRaidMembers() do
 				if UnitName("Raid"..i) == rest then
-					if UnitName("Raid"..i.."Target") == "Vaelastrasz the Corrupt" and UnitName("Raid"..i.."TargetTarget") ~= nil then
+					if UnitName("Raid"..i.."Target") == bbvaelastraszthecorrupt and UnitName("Raid"..i.."TargetTarget") ~= nil then
 						if UnitName("Raid"..i.."TargetTarget") == rest then
 							SetRaidTarget("Raid"..i, 6)
 						else

--- a/Raids/BWL/Wyrmguards.lua
+++ b/Raids/BWL/Wyrmguards.lua
@@ -59,7 +59,7 @@ L:RegisterTranslations("zhCN", function() return {
 	warstomp_trigger = "死爪龙人护卫的战争践踏",
 	warstomp_bar = "战争践踏 CD",
 	
-	vulnerability_direct_test = "^[%w\u4e00-\u9fa5]+[%s的]*([%w\u4e00-\u9fa5]+)[%s]*击中死爪龙人护卫造成[%s]*([%d]+)[%s]*点([%w\u4e00-\u9fa5]+)伤害%。?[%s%(]*([%d]*)?",
+	vulnerability_direct_test = "^[^%s]+的([^%s]+)[%s]*([^%s]+)死爪龙人护卫造成[%s]*([%d]+)[%s]*点([^%s]+)伤害%。?[%s%(]*([%d]*)?",
 	vulnerability_dots_test = "^[^%s]+的([^%s]+)使死爪龙人护卫受到了(%d+)点([^%s]+)伤害。",
 	vulnerability_message = "弱点：%s！",
 	
@@ -326,4 +326,3 @@ function module:IdentifyVulnerability(school)
 		bwWyrmguardsShadowBar = true
 	end
 end
-

--- a/Raids/BWL/Wyrmguards.lua
+++ b/Raids/BWL/Wyrmguards.lua
@@ -39,7 +39,41 @@ L:RegisterTranslations("enUS", function() return {
 	starfire = "Starfire",
 	thunderfury = "Thunderfury",
 } end )
-
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Wyrmguard",
+	
+	warstomp_cmd = "warstomp",
+	warstomp_name = "战争践踏警报",
+	warstomp_desc = "战争践踏出现时进行警告",
+	
+	vulnerability_cmd = "vulnerability",
+	vulnerability_name = "弱点",
+	vulnerability_desc = "弱点发生变化时进行警告",
+	
+	hit = "击中",
+	crit = "致命一击对",
+	vuln_bar = "%s 弱点",
+	
+	warstomp_trigger = "死爪龙人护卫的战争践踏",
+	warstomp_bar = "战争践踏 CD",
+	
+	vulnerability_direct_test = "^[%w\u4e00-\u9fa5]+[%s的]*([%w\u4e00-\u9fa5]+)[%s]*击中死爪龙人护卫造成[%s]*([%d]+)[%s]*点([%w\u4e00-\u9fa5]+)伤害%。?[%s%(]*([%d]*)?",
+	vulnerability_dots_test = "^[^%s]+的([^%s]+)使死爪龙人护卫受到了(%d+)点([^%s]+)伤害。",
+	vulnerability_message = "弱点：%s！",
+	
+	fire = "火焰",
+	frost = "冰霜",
+	shadow = "暗影",
+	nature = "自然",
+	arcane = "奥术",
+	
+	curseofdoom = "厄运诅咒",
+	ignite = "点燃",
+	starfire = "星火术",
+	thunderfury = "雷霆之怒",
+} end )
 local timer = {
 	warstomp = {8.5, 12.5},
 	vulnerability = 599,

--- a/Raids/MC/AncientCoreHound.lua
+++ b/Raids/MC/AncientCoreHound.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Ancient Core Hound", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30074
 module.enabletrigger = module.translatedName
@@ -40,11 +41,11 @@ L:RegisterTranslations("enUS", function() return {
 L:RegisterTranslations("zhCN", function() return {
 	-- Wind汉化修复Turtle-WOW中文数据
 	-- Last update: 2024-06-22
-    cmd = "Corehound",
+	cmd = "Corehound",
 
-    bars_cmd = "bars",
-    bars_name = "切换计时条",
-    bars_desc = "切换显示计时条的状态。",
+	bars_cmd = "bars",
+	bars_name = "切换计时条",
+	bars_desc = "切换显示计时条的状态。",
 
 
 	trigger_debuff = "你受到了(.+)效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
@@ -52,24 +53,24 @@ L:RegisterTranslations("zhCN", function() return {
 	trigger_debuffResist = ".*的(.+)被.*抵抗了。", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
 	bar_debuff = "Debuff",
 
-    msg_ancientDread = "上古恐慌 - 驱散！",
+	msg_ancientDread = "上古恐慌 - 驱散！",
 
-    bar_ancientDespair = "迷惑",
+	bar_ancientDespair = "迷惑",
 
-    bar_groundStomp = "大地践踏",
+	bar_groundStomp = "大地践踏",
 
-    msg_cauterizingFlames = "灼烧之焰 - 驱散！",
+	msg_cauterizingFlames = "灼烧之焰 - 驱散！",
 
-    msg_witheringHeat = "枯萎热浪 - 驱散！",
+	msg_witheringHeat = "枯萎热浪 - 驱散！",
 
-    msg_ancientHysteria = "上古狂乱 - 解除诅咒！",
+	msg_ancientHysteria = "上古狂乱 - 解除诅咒！",
 
-    s_ancientdread = "上古恐慌",
-    s_ancientdespair = "上古绝望",
-    s_groundstomp = "大地践踏",
-    s_cauterizingflames = "灼烧之焰",
-    s_witheringheat = "枯萎热浪",
-    s_ancienthysteria = "上古狂乱",
+	s_ancientdread = "上古恐慌",
+	s_ancientdespair = "上古绝望",
+	s_groundstomp = "大地践踏",
+	s_cauterizingflames = "灼烧之焰",
+	s_witheringheat = "枯萎热浪",
+	s_ancienthysteria = "上古狂乱",
 } end )
 
 local timer = {
@@ -170,7 +171,7 @@ function module:Debuff(rest)
 
 	if rest == L["s_ancientdread"] then
 		self:Bar(L["bar_debuff"], timer.debuff, icon.debuff, true, color.debuff)
-		if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+		if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 			self:Message(L["msg_ancientDread"], "Urgent", false, nil, false)
 			self:Sound("Info")
 			self:WarningSign(icon.ancientDread, 1)
@@ -188,7 +189,7 @@ function module:Debuff(rest)
 
 	elseif rest == L["s_cauterizingflames"] then
 		self:Bar(L["bar_debuff"], timer.debuff, icon.debuff, true, color.debuff)
-		if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+		if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 			self:Message(L["msg_cauterizingFlames"], "Urgent", false, nil, false)
 			self:Sound("Info")
 			self:WarningSign(icon.cauterizingFlames, 1)
@@ -196,7 +197,7 @@ function module:Debuff(rest)
 
 	elseif rest == L["s_witheringheat"] then
 		self:Bar(L["bar_debuff"], timer.debuff, icon.debuff, true, color.debuff)
-		if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+		if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 			self:Message(L["msg_witheringHeat"], "Urgent", false, nil, false)
 			self:Sound("Info")
 			self:WarningSign(icon.witheringHeat, 1)
@@ -204,7 +205,7 @@ function module:Debuff(rest)
 
 	elseif rest == L["s_ancienthysteria"] then
 		self:Bar(L["bar_debuff"], timer.debuff, icon.debuff, true, color.debuff)
-		if UnitClass("Player") == "Mage" or UnitClass("Player") == "Druid" then
+		if UnitClass("Player") == BC["Mage"] or UnitClass("Player") == BC["Druid"] then
 			self:Message(L["msg_ancientHysteria"], "Urgent", false, nil, false)
 			self:Sound("Info")
 			self:WarningSign(icon.ancientHysteria, 1)

--- a/Raids/MC/BaronGeddon.lua
+++ b/Raids/MC/BaronGeddon.lua
@@ -1,5 +1,7 @@
 
 local module, L = BigWigs:ModuleDeclaration("Baron Geddon", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
+local bbbarongeddon = AceLibrary("Babble-Boss-2.2")["Baron Geddon"]
 
 module.revision = 30075
 module.enabletrigger = module.translatedName
@@ -38,6 +40,7 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_bombFade = "Living Bomb fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
 	bar_bomb = " Bomb!",
 	msg_bomb = " is the Bomb!",
+	msg_bombSay = " is the Bomb!",
 	
 	trigger_inferno = "Baron Geddon gains Inferno.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
 	trigger_infernoFade = "Inferno fades from Baron Geddon.", --CHAT_MSG_SPELL_AURA_GONE_OTHER
@@ -56,6 +59,60 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_ignite2 = "Ignite Mana was resisted", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
 	bar_igniteCd = "Ignite Mana CD",
 	msg_ignite = "Ignite Man - Dispel! (Classes with Mana only)",
+	you = "you",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Baron",
+
+	bomb_cmd = "bomb",
+	bomb_name = "活化炸弹警报",
+	bomb_desc = "活化炸弹出现时进行警告",
+
+	inferno_cmd = "inferno",
+	inferno_name = "地狱火警报",
+	inferno_desc = "地狱火出现时进行警告",
+
+	armageddon_cmd = "armageddon",
+	armageddon_name = "末日决战警报",
+	armageddon_desc = "末日决战出现时进行警告",
+
+	ignite_cmd = "ignite",
+	ignite_name = "点燃法力警报",
+	ignite_desc = "点燃法力出现时进行警告",
+
+	icon_cmd = "icon",
+	icon_name = "炸弹目标团队图标",
+	icon_desc = "在成为炸弹的玩家上标记团队图标。（需要助理或更高权限）",
+	
+	
+	trigger_bombYou = "你受到了活化炸弹效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_bombOther = "(.*)受到了活化炸弹效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_bombFade = "活化炸弹效果从(.*)身上消失。", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_bomb = " 炸弹！",
+	msg_bomb = " 是炸弹！",
+	msg_bombSay = " 是炸弹！",
+	
+	trigger_inferno = "迦顿男爵获得了地狱火的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_infernoFade = "地狱火效果从迦顿男爵身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_infernoCd = "地狱火冷却",
+	bar_infernoSoon = "即将地狱火...",
+	bar_infernoChannel = "地狱火！",
+	
+	trigger_infernoYou = "迦顿男爵的地狱火击中你造成", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
+	msg_infernoYou = "远离地狱火！",
+	
+	trigger_armageddon = "迦顿男爵受到了末日决战效果的影响。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE
+	bar_armageddon = "末日决战！",
+	msg_armageddon = "末日决战 - 杀死迦顿男爵！",
+	
+	trigger_ignite = "受到了点燃法力效果的影响", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_ignite2 = "点燃法力被抵抗了", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_igniteCd = "点燃法力冷却",
+	msg_ignite = "点燃法力 - 驱散！(仅限有法力值的职业)",
+	you = "你",
 } end)
 
 local timer = {
@@ -159,7 +216,7 @@ function module:Event(msg)
 		
 	elseif string.find(msg, L["trigger_bombFade"]) then
 		local _,_, bombFadePlayer,_ = string.find(msg, L["trigger_bombFade"])
-		if bombFadePlayer == "you" then bombFadePlayer = UnitName("Player") end
+		if bombFadePlayer == L["you"] then bombFadePlayer = UnitName("Player") end
 		self:Sync(syncName.bombFade .. " " .. bombFadePlayer)
 		
 		
@@ -206,7 +263,7 @@ function module:Bomb(rest)
 	self:Message(rest..L["msg_bomb"], "Urgent", false, nil, false)
 	
 	if rest == UnitName("Player") then
-		SendChatMessage(UnitName("Player").." is the Bomb!","SAY")
+		SendChatMessage(UnitName("Player")..L["msg_bombSay"],"SAY")
 		self:WarningSign(icon.bomb, timer.bomb)
 		self:Sound("RunAway")
 	end
@@ -248,7 +305,7 @@ function module:InfernoFade()
 end
 
 function module:InfernoYou()
-	if UnitName("Target") == "Baron Geddon" and UnitName("TargetTarget") == UnitName("Player") then return end
+	if UnitName("Target") == bbbarongeddon and UnitName("TargetTarget") == UnitName("Player") then return end
 	
 	self:Message(L["msg_infernoYou"], "Personal", false, nil, false)
 	self:Sound("Info")
@@ -270,7 +327,7 @@ end
 function module:Ignite()
 	self:IntervalBar(L["bar_igniteCd"], timer.igniteCd[1], timer.igniteCd[2], icon.ignite, true, color.ignite)
 
-	if UnitClass("Player") == "Paladin" or UnitClass("Player") == "Priest" then
+	if UnitClass("Player") == BC["Paladin"] or UnitClass("Player") == BC["Priest"] then
 		self:WarningSign(icon.ignite, 0.7)
 		self:Sound("Info")
 		self:Message(L["msg_ignite"], "Important", false, nil, false)

--- a/Raids/MC/CoreHound.lua
+++ b/Raids/MC/CoreHound.lua
@@ -36,19 +36,24 @@ L:RegisterTranslations("enUS", function() return {
 L:RegisterTranslations("zhCN", function() return {
 	-- Wind汉化修复Turtle-WOW中文数据
 	-- Last update: 2024-06-22
-    cmd = "CoreHound",
+	cmd = "CoreHound",
 
 	respawn_cmd = "respawn",
-    respawn_name = "重生警报",
-    respawn_desc = "重生出现时进行警告",
+	respawn_name = "重生警报",
+	respawn_desc = "重生出现时进行警告",
+
+	despawn_cmd = "despawn",
+	despawn_name = "消失计时",
+	despawn_desc = "尸体消失倒计时",
 	
 	
 	trigger_smolder = "熔火恶犬.*开始.*smolder",
-    bar_respawn = "重生",
-    msg_respawn = "在10秒内杀死所有熔火恶犬",
+	bar_respawn = "重生",
+	msg_respawn = "在10秒内杀死所有熔火恶犬",
+	bar_despawn = "消失",
+	msg_despawn = "熔火恶犬已消失",
 
-    ["You have slain %s!"] = true,
-    ["You have slain %s!"] = "你击杀了 %s！",
+	["You have slain %s!"] = "你击杀了 %s！",
 } end )
 
 local timer = {

--- a/Raids/MC/CoreHound.lua
+++ b/Raids/MC/CoreHound.lua
@@ -47,7 +47,7 @@ L:RegisterTranslations("zhCN", function() return {
 	despawn_desc = "尸体消失倒计时",
 	
 	
-	trigger_smolder = "熔火恶犬.*开始.*smolder",
+	trigger_smolder = "(.+)倒下并开始冒烟",
 	bar_respawn = "重生",
 	msg_respawn = "在10秒内杀死所有熔火恶犬",
 	bar_despawn = "消失",

--- a/Raids/MC/FlameImp.lua
+++ b/Raids/MC/FlameImp.lua
@@ -22,6 +22,20 @@ L:RegisterTranslations("enUS", function() return {
 
 	bar_respawn = " Respawn",
 	msg_respawn = "Imp Pack will respawn in 7 minutes - Right-click the BigWigs icon to remove the bar",
+	c_flameimp = "Flame Imp",
+} end )
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "FlameImp",
+
+	respawn_cmd = "respawn",
+	respawn_name = "重生警报",
+	respawn_desc = "重生出现时进行警告",
+
+	bar_respawn = " 重生",
+	msg_respawn = "小鬼群将在7分钟后重生 - 点击BigWigs图标以移除计时条",
+	c_flameimp = "烈焰小鬼",
 } end )
 
 local timer = {
@@ -61,7 +75,7 @@ function module:CheckForWipe()
 end
 
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
-	if (msg == string.format(UNITDIESOTHER, "Flame Imp")) then
+	if (msg == string.format(UNITDIESOTHER, L["c_flameimp"])) then
 		self:Sync(syncName.dead)
 	end
 end

--- a/Raids/MC/Garr.lua
+++ b/Raids/MC/Garr.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Garr", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30078
 module.enabletrigger = module.translatedName
@@ -38,6 +39,48 @@ L:RegisterTranslations("enUS", function() return {
 		--instead only showing the message once to remind dispels on Garr
 	trigger_immolate = "Fire damage from Firesworn's Immolate.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
 	msg_immolate = "Immolate - Dispel!",
+	c_firesworn = "Firesworn",
+	c_garr = "Garr",
+	s_immolate = "Immolate",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Garr",
+	
+	pulse_cmd = "pulse",
+	pulse_name = "反魔法脉冲警报",
+	pulse_desc = "反魔法脉冲出现时进行警告",
+
+	remove_cmd = "remove",
+	remove_name = "增益移除警报",
+	remove_desc = "增益移除时进行警告",
+
+	adds_cmd = "adds",
+	adds_name = "小怪死亡警报",
+	adds_desc = "小怪死亡时进行警告",
+
+	immolate_cmd = "immolate",
+	immolate_name = "献祭警报",
+	immolate_desc = "献祭出现时进行警告",
+	
+	
+	trigger_antimagicPulse = "加尔对你使用反魔法脉冲。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_antimagicPulse = "反魔法脉冲",
+
+	trigger_remove = "你的(.+)被移除了。", --CHAT_MSG_SPELL_BREAK_AURA
+	msg_remove = "反魔法脉冲移除了你的",
+
+	msg_addDead = "/8 火誓者死亡",
+	
+	--not tracking the afflicted since many mobs do immolate, may cause conflict
+		--instead only showing the message once to remind dispels on Garr
+	trigger_immolate = "点火焰伤害（火誓者的献祭）。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	msg_immolate = "献祭 - 驱散！",
+	c_firesworn = "火誓者",
+	c_garr = "加尔",
+	s_immolate = "献祭",
 } end)
 
 local timer = {
@@ -102,12 +145,12 @@ end
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	BigWigs:CheckForBossDeath(msg, self)
 
-	if (msg == string.format(UNITDIESOTHER, "Firesworn")) then
+	if (msg == string.format(UNITDIESOTHER, L["c_firesworn"])) then
 		addDead = addDead + 1
 		if addDead <= 8 then
 			self:Sync(syncName.addDead .. " " .. addDead)
 		end
-	elseif (msg == string.format(UNITDIESOTHER, "Garr")) then
+	elseif (msg == string.format(UNITDIESOTHER, L["c_garr"])) then
 		fightningGarr = false
 	end
 end
@@ -118,7 +161,7 @@ function module:Event(msg)
 	
 	elseif string.find(msg, L["trigger_remove"]) and fightningGarr == true and self.db.profile.remove then
 		local _,_, removedBuff, _ = string.find(msg, L["trigger_remove"])
-		if removedBuff ~= "Immolate" then
+		if removedBuff ~= L["s_immolate"] then
 			self:Remove(removedBuff)
 		end
 		
@@ -153,7 +196,7 @@ function module:AddDead(rest)
 end
 
 function module:Immolate()
-	if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 		self:Message(L["msg_immolate"], "Urgent", false, nil, false)
 		self:WarningSign(icon.immolate, 1)
 	end

--- a/Raids/MC/Golemagg.lua
+++ b/Raids/MC/Golemagg.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Golemagg the Incinerator", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30075
 module.enabletrigger = module.translatedName
@@ -31,6 +32,35 @@ L:RegisterTranslations("enUS", function() return {
 	
 	trigger_magmaSplash = "You are afflicted by Magma Splash %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
 	msg_magmaSplash = "Warning - High Magma Splash Stacks: ",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Golemagg",
+
+	enrage_cmd = "enrage",
+	enrage_name = "激怒警报",
+	enrage_desc = "激怒出现时进行警告",
+
+	earthquake_cmd = "earthquake",
+	earthquake_name = "地震术警报",
+	earthquake_desc = "地震术出现时进行警告",
+
+	magma_cmd = "magma",
+	magma_name = "熔岩喷溅警报",
+	magma_desc = "熔岩喷溅出现时进行警告",
+	
+	
+	trigger_enrage = "焚化者古雷曼格获得了激怒的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	msg_enrage = "焚化者古雷曼格激怒了 - 正在施放地震术！",
+	msg_enrageSoon = "即将激怒（在10%时） - 即将地震",
+	
+	trigger_earthquake = "焚化者古雷曼格的地震术", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_earthquake = "地震术",
+	
+	trigger_magmaSplash = "你受到了熔岩喷溅效果的影响%（(.+)%）。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	msg_magmaSplash = "警告 - 熔岩喷溅层数过高：",
 } end)
 
 local timer = {
@@ -127,7 +157,7 @@ end
 function module:EnrageSoon()
 	enrageSoon = true
 	
-	if UnitClass("Player") == "Warrior" or UnitClass("Player") == "Rogue" or UnitClass("Player") == "Paladin" or UnitClass("Player") == "Shaman" or UnitClass("Player") == "Druid" then
+	if UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Paladin"] or UnitClass("Player") == BC["Shaman"] or UnitClass("Player") == BC["Druid"] then
 		self:Message(L["msg_enrageSoon"], "Attention", false, nil, false)
 	end
 end

--- a/Raids/MC/Incindis.lua
+++ b/Raids/MC/Incindis.lua
@@ -20,6 +20,18 @@ L:RegisterTranslations("enUS", function() return {
 	msg_fireNova = "FIRE NOVA - RUN AWAY!",
 } end)
 
+L:RegisterTranslations("zhCN", function() return {
+	cmd = "Incindis",
+
+	firenova_cmd = "firenova",
+	firenova_name = "火焰新星警报",
+	firenova_desc = "震颤践踏后提示即将到来的火焰新星",
+
+	trigger_quakingStomp = "因辛迪欧斯的震颤践踏击中(.+)造成",
+	bar_fireNova = "火焰新星！",
+	msg_fireNova = "火焰新星 - 赶快跑开！",
+} end)
+
 local timer = {
 	fireNova = 5.5,
 }

--- a/Raids/MC/Lucifron.lua
+++ b/Raids/MC/Lucifron.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Lucifron", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30085
 module.enabletrigger = module.translatedName
@@ -60,6 +61,73 @@ L:RegisterTranslations("enUS", function() return {
 
 	trigger_deadYou = "You die.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
 	trigger_deadOther = "(.+) dies.", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	c_flamewakerprotector = "Flamewaker Protector",
+	c_lucifron = "Lucifron",
+	clickme = ">Click me<",
+	you = "you",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Lucifron",
+	
+	curse_cmd = "curse",
+	curse_name = "鲁西弗隆的诅咒警报",
+	curse_desc = "鲁西弗隆的诅咒出现时进行警告",
+
+	doom_cmd = "doom",
+	doom_name = "末日降临警报",
+	doom_desc = "末日降临出现时进行警告",
+
+	mc_cmd = "mc",
+	mc_name = "统御意志警报",
+	mc_desc = "统御意志出现时进行警告",
+
+	shock_cmd = "shock",
+	shock_name = "暗影震击警报",
+	shock_desc  = "暗影震击出现时进行警告",
+
+	adds_cmd = "adds",
+	adds_name = "小怪死亡警报",
+	adds_desc = "小怪死亡时进行警告",
+
+
+	trigger_curse = "受到了鲁西弗隆的诅咒效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_curse2 = "鲁西弗隆的诅咒被抵抗", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_curseCd = "下一次鲁西弗隆的诅咒",
+	msg_curse = "鲁西弗隆的诅咒 - 解除诅咒！",
+	
+	trigger_doom = "受到了末日降临效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_doom2 = "末日降临被抵抗", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_doomCd = "下一次末日降临",
+	bar_doomDmg = "末日降临！",
+	msg_doom = "末日降临 - 驱散！",
+	
+	trigger_shadowShock = "鲁西弗隆的暗影震击", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_shadowShockCd = "暗影震击冷却",
+	
+	trigger_mcYou = "你受到了统御意志效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+	trigger_mcOther2 = "(.+) %(.+%)受到了统御意志效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_mcOther = "(.*)受到了统御意志效果的影响。", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE
+	trigger_mcFade = "统御意志效果从(.+)身上消失", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_mcCd = "统御意志冷却",
+	bar_mc = " 统御意志 ",
+	msg_mc = " 统御意志 - 驱散！",
+	
+	trigger_mcCast = "开始施放统御意志", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_mcCast = "施放统御意志！",
+	msg_mcCast = "施放统御意志 - 打断！",
+	
+	msg_addDead = "/2 烈焰行者护卫死亡",
+
+	trigger_deadYou = "你死了。", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	trigger_deadOther = "(.*)死亡了。", --CHAT_MSG_COMBAT_FRIENDLY_DEATH
+	
+	c_flamewakerprotector = "烈焰行者护卫",
+	c_lucifron = "鲁西弗隆",
+	clickme = ">点击我<",
+	you = "你",
 } end)
 
 local timer = {
@@ -172,7 +240,7 @@ end
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	BigWigs:CheckForBossDeath(msg, self)
 
-	if (msg == string.format(UNITDIESOTHER, "Flamewaker Protector")) then
+	if (msg == string.format(UNITDIESOTHER, L["c_flamewakerprotector"])) then
 		addDead = addDead + 1
 		if addDead <= 2 then
 			self:Sync(syncName.addDead .. " " .. addDead)
@@ -180,7 +248,7 @@ function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	
 	elseif string.find(msg, L["trigger_deadOther"]) then
 		local _,_, deadPerson, _ = string.find(msg, L["trigger_deadOther"])
-		if deadPerson ~= "Flamewaker Protector" and deadPerson ~= "Lucifron" then
+		if deadPerson ~= L["c_flamewakerprotector"] and deadPerson ~= L["c_lucifron"] then
 			self:Sync(syncName.mcFade .. " " .. deadPerson)
 		end
 	end
@@ -210,7 +278,7 @@ function module:Event(msg)
 	
 	elseif string.find(msg, L["trigger_mcFade"]) then
 		local _,_, mcFadePerson, _ = string.find(msg, L["trigger_mcFade"])
-		if mcFadePerson == "you" then mcFadePerson = UnitName("Player") end
+		if mcFadePerson == L["you"] then mcFadePerson = UnitName("Player") end
 		self:Sync(syncName.mcFade .. " " .. mcFadePerson)
 
 	elseif msg == L["trigger_deadYou"] then
@@ -252,7 +320,7 @@ end
 
 function module:Curse()
 	self:Bar(L["bar_curseCd"], timer.curseCd, icon.curse, true, color.curse)
-	if UnitClass("Player") == "Mage" or UnitClass("Player") == "Druid" then
+	if UnitClass("Player") == BC["Mage"] or UnitClass("Player") == BC["Druid"] then
 		self:Message(L["msg_curse"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.curse, 1)
@@ -263,7 +331,7 @@ function module:ImpendingDoom()
 	self:RemoveBar(L["bar_doomCd"])
 	
 	self:Bar(L["bar_doomDmg"], timer.impendingDoomDur, icon.impendingDoom, true, color.impendingDoomDur)
-	if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 		self:Message(L["msg_doom"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.impendingDoom, 1)
@@ -276,7 +344,7 @@ function module:McCast()
 	self:RemoveBar(L["bar_mcCd"])
 	
 	self:Bar(L["bar_mcCast"], timer.mcCast, icon.mc, true, color.mcCast)
-	if UnitClass("Player") == "Warrior" or UnitClass("Player") == "Rogue" or UnitClass("Player") == "Mage" then
+	if UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Mage"] then
 		self:Message(L["msg_mcCast"], "Important", false, nil, false)
 		self:WarningSign(icon.mc, 0.7)
 	end
@@ -293,10 +361,10 @@ function module:Mc(rest)
 		end
 	end
 		
-	self:Bar(rest..L["bar_mc"].. ">Click Me<", timer.mc, icon.mc, true, color.mc)
-	self:SetCandyBarOnClick("BigWigsBar "..rest..L["bar_mc"].. ">Click Me<", function(name, button, extra) TargetByName(extra, true) end, rest)
+	self:Bar(rest..L["bar_mc"].. L["clickme"], timer.mc, icon.mc, true, color.mc)
+	self:SetCandyBarOnClick("BigWigsBar "..rest..L["bar_mc"].. L["clickme"], function(name, button, extra) TargetByName(extra, true) end, rest)
 	
-	if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 		self:Message(rest..L["msg_mc"], "Attention", false, nil, false)
 		self:Sound("Beware")
 		self:WarningSign(icon.mc, 0.7)
@@ -306,7 +374,7 @@ end
 
 
 function module:McFade(rest)
-	self:RemoveBar(rest..L["bar_mc"].. ">Click Me<")
+	self:RemoveBar(rest..L["bar_mc"].. L["clickme"])
 	
 	if IsRaidLeader() or IsRaidOfficer() then
 		for i=1,GetNumRaidMembers() do

--- a/Raids/MC/Magmadar.lua
+++ b/Raids/MC/Magmadar.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Magmadar", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30073
 module.enabletrigger = module.translatedName
@@ -35,6 +36,40 @@ L:RegisterTranslations("enUS", function() return {
 	msg_frenzy = "Frenzy - Tranq now!",
 	
 	trigger_conflagYou = "You are afflicted by Conflagration.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Magmadar",
+
+	panic_cmd = "panic",
+	panic_name = "恐惧警报",
+	panic_desc = "当玛格曼达施放恐慌时进行警告",
+
+	frenzy_cmd = "frenzy",
+	frenzy_name = "狂暴警报",
+	frenzy_desc = "当玛格曼达进入狂暴状态时进行警告",
+
+	conflagration_cmd = "conflagration",
+	conflagration_name = "燃烧警报",
+	conflagration_desc = "燃烧出现时进行警告",
+	
+	
+	trigger_panic = "受到了恐慌效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_panic2 = "恐慌施放失败。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_panic3 = "玛格曼达的恐慌被抵抗了。", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_panicCd = "恐惧冷却",
+	bar_panicSoon = "即将恐惧...",
+	msg_panic = "恐惧 - 驱散！",
+	
+	trigger_frenzy = "玛格曼达获得了狂乱的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_frenzyFade = "狂乱效果从玛格曼达身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_frenzyCd = "狂暴冷却",
+	bar_frenzyDur = "狂暴！",
+	msg_frenzy = "狂暴 - 立即宁神！",
+	
+	trigger_conflagYou = "你受到了燃烧效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
 } end)
 
 local timer = {
@@ -102,9 +137,9 @@ function module:OnEngage()
 	if self.db.profile.panic then
 		self:Bar(L["bar_panicCd"], timer.panicFirstCd, icon.panic, true, color.panicCd)
 		
-		if UnitClass("Player") == "Warrior" then
+		if UnitClass("Player") == BC["Warrior"] then
 			self:WarningSign(icon.berserkerRage, 0.7)
-		elseif UnitClass("Player") == "Shaman" then
+		elseif UnitClass("Player") == BC["Shaman"] then
 			self:DelayedWarningSign(5, icon.tremor, 0.7)
 		end
 	end
@@ -154,7 +189,7 @@ function module:Panic()
 	self:RemoveWarningSign(icon.tremor)
 	
 	self:Bar(L["bar_panicCd"], timer.panicCd, icon.panic, true, color.panicCd)
-	if UnitClass("Player") == "Priest" or  UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or  UnitClass("Player") == BC["Paladin"] then
 		self:Message(L["msg_panic"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.panic, 0.7)
@@ -162,9 +197,9 @@ function module:Panic()
 	
 	self:DelayedBar(timer.panicCd, L["bar_panicSoon"], timer.panicSoon, icon.panic, true, color.panicSoon)
 	
-	if UnitClass("Player") == "Warrior" then
+	if UnitClass("Player") == BC["Warrior"] then
 		self:DelayedWarningSign(timer.panicCd + timer.panicSoon - 10, icon.berserkerRage, 0.7)
-	elseif UnitClass("Player") == "Shaman" then
+	elseif UnitClass("Player") == BC["Shaman"] then
 		self:DelayedWarningSign(timer.panicCd, icon.tremor, 0.7)
 	end
 end
@@ -172,7 +207,7 @@ end
 function module:Frenzy()
 	self:RemoveBar(L["bar_frenzyCd"])
 	
-	if UnitClass("Player") == "Hunter" then
+	if UnitClass("Player") == BC["Hunter"] then
 		self:Message(L["msg_frenzy"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.tranquil, 1)

--- a/Raids/MC/Majordomo.lua
+++ b/Raids/MC/Majordomo.lua
@@ -1,4 +1,5 @@
 local module, L = BigWigs:ModuleDeclaration("Majordomo Executus", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30075
 module.enabletrigger = module.translatedName
@@ -47,8 +48,56 @@ L:RegisterTranslations("enUS", function()
 		msg_healerDead = "/4 Flamewaker Healer Dead",
 
 		trigger_firePitYou = "You suffer (.+) points of fire damage.", --CHAT_MSG_COMBAT_SELF_HITS
+		c_flamewakerelite = "Flamewaker Elite",
+		c_flamewakerhealer = "Flamewaker Healer",
 	}
 end)
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Majordomo",
+
+	magicreflect_cmd = "magicreflect",
+	magicreflect_name = "魔法反射警报",
+	magicreflect_desc = "魔法反射出现时进行警告",
+
+	physicalreflect_cmd = "physicalreflect",
+	physicalreflect_name = "物理反射警报",
+	physicalreflect_desc = "物理反射出现时进行警告",
+	
+	adds_cmd = "adds",
+	adds_name = "小怪死亡警报",
+	adds_desc = "小怪死亡时进行警告",
+	
+	firepit_cmd = "firepit",
+	firepit_name = "火焰喷射伤害警报",
+	firepit_desc = "火焰喷射伤害出现时进行警告",
+	
+	
+	trigger_engage = "狂妄的凡人，没有人可以挑战生命之焰的儿子！", --CHAT_MSG_MONSTER_YELL
+	
+	--is MUCH longer than that
+	trigger_bossDeath = "不可能！住手吧，凡人们......我投降！我投降！", --CHAT_MSG_MONSTER_YELL
+	
+	bar_reflectCd = "反射冷却",
+	
+	trigger_magicReflect = "获得了魔法反射的效果", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS"
+	trigger_magicReflectFade = "魔法反射效果从", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_magicReflect = "魔法反射",
+	msg_magicReflect = "魔法反射 - 停止施法！",
+	
+	trigger_physicalReflect = "获得了伤害反射护盾的效果", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_physicalReflectFade = "伤害反射护盾效果从", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_physicalReflect = "物理反射",
+	msg_physicalReflect = "物理反射 - 停止攻击！",
+	
+	msg_eliteDead = "/4 烈焰行者精英死亡",
+	msg_healerDead = "/4 烈焰行者医师死亡",
+	
+	trigger_firePitYou = "你受到了(.+)点火焰伤害。", --CHAT_MSG_COMBAT_SELF_HITS
+	c_flamewakerelite = "烈焰行者精英",
+	c_flamewakerhealer = "烈焰行者医师",
+} end)
 
 local timer = {
 	reflectFirstCd = 30, --saw 29.816
@@ -123,13 +172,13 @@ end
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	BigWigs:CheckForBossDeath(msg, self)
 
-	if (msg == string.format(UNITDIESOTHER, "Flamewaker Elite")) then
+	if (msg == string.format(UNITDIESOTHER, L["c_flamewakerelite"])) then
 		eliteDead = eliteDead + 1
 		if eliteDead <= 4 then
 			self:Sync(syncName.eliteDead .. " " .. eliteDead)
 		end
 
-	elseif (msg == string.format(UNITDIESOTHER, "Flamewaker Healer")) then
+	elseif (msg == string.format(UNITDIESOTHER, L["c_flamewakerhealer"])) then
 		healerDead = healerDead + 1
 		if healerDead <= 4 then
 			self:Sync(syncName.healerDead .. " " .. healerDead)
@@ -184,7 +233,7 @@ function module:MagicReflect()
 
 	self:Bar(L["bar_magicReflect"], timer.reflectDur, icon.magicReflect, true, color.magicReflect)
 
-	if not (UnitClass("Player") == "Warrior" or UnitClass("Player") == "Rogue" or UnitClass("Player") == "Hunter") then
+	if not (UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Hunter"]) then
 		self:Message(L["msg_magicReflect"], "Attention", false, nil, false)
 		self:Sound("Beware")
 		self:WarningSign(icon.magicReflect, 1)
@@ -201,7 +250,7 @@ function module:PhysicalReflect()
 
 	self:Bar(L["bar_physicalReflect"], timer.reflectDur, icon.physicalReflect, true, color.physicalReflect)
 
-	if not (UnitClass("Player") == "Priest" or UnitClass("Player") == "Mage" or UnitClass("Player") == "Warlock") then
+	if not (UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Mage"] or UnitClass("Player") == BC["Warlock"]) then
 		self:Message(L["msg_physicalReflect"], "Attention", false, nil, false)
 		self:Sound("Beware")
 		self:WarningSign(icon.physicalReflect, 1)

--- a/Raids/MC/Shazzrah.lua
+++ b/Raids/MC/Shazzrah.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Shazzrah", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30075
 module.enabletrigger = module.translatedName
@@ -48,6 +49,55 @@ L:RegisterTranslations("enUS", function() return {
 	bar_blinkCd = "Blink CD",
 	bar_blinkSoon = "Blink Soon...",
 	msg_blink = "Blink - Aggro Drop!",
+	c_shazzrah = "Shazzrah",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Shazzrah",
+
+	counterspell_cmd = "counterspell",
+	counterspell_name = "法术反制警报",
+	counterspell_desc = "法术反制出现时进行警告",
+
+	curse_cmd = "curse",
+	curse_name = "沙斯拉尔的诅咒警报",
+	curse_desc = "沙斯拉尔的诅咒出现时进行警告",
+
+	deaden_cmd = "deaden",
+	deaden_name = "衰减魔法警报",
+	deaden_desc = "衰减魔法出现时进行警告",
+
+	blink_cmd = "blink",
+	blink_name = "闪现警报",
+	blink_desc = "闪现出现时进行警告",
+	
+	
+	trigger_counterspell = "沙斯拉尔打断了", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	trigger_counterspell2 = "沙斯拉尔的法术反制被(.+)抵抗了。", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_counterspellCd = "法术反制冷却",
+	bar_counterspellSoon = "即将法术反制...",
+	msg_counterspellSoon = "即将法术反制 - 停止施法！",
+	msg_counterspell = "法术反制完毕 - 开始施法！",
+	
+	trigger_curse = "受到了沙斯拉尔的诅咒效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	trigger_curse2 = "沙斯拉尔的诅咒被(.+)抵抗了。", --CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_curseCd = "沙斯拉尔的诅咒冷却",
+	msg_curse = "沙斯拉尔的诅咒 - 解除诅咒！",
+	
+	trigger_deaden = "沙斯拉尔获得了衰减魔法的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	trigger_deadenFade = "衰减魔法效果从沙斯拉尔身上消失。", --CHAT_MSG_SPELL_AURA_GONE_OTHER
+	bar_deadenCd = "衰减魔法冷却",
+	bar_deadenDur = "衰减魔法已开启！",
+	msg_deaden = "衰减魔法 - 驱散它！",
+	
+	--there is no trigger blink
+		--instead, checking for target change, if found, expecting a blink to have happenned
+	bar_blinkCd = "闪现冷却",
+	bar_blinkSoon = "即将闪现...",
+	msg_blink = "闪现 - 仇恨重置！",
+	c_shazzrah = "沙斯拉尔",
 } end)
 
 local timer = {
@@ -136,7 +186,7 @@ function module:OnEngage()
 	if self.db.profile.counterspell then
 		self:Bar(L["bar_counterspellCd"], timer.counterspellFirstCd, icon.counterspell, true, color.counterspellCd)
 		
-		if not (UnitClass("Player") == "Warrior" or UnitClass("Player") == "Rogue" or UnitClass("Player") == "Hunter") then
+		if not (UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Hunter"]) then
 			self:DelayedBar(timer.counterspellFirstCd, L["bar_counterspellSoon"], timer.counterspellSoon, icon.counterspell, true, color.counterspellSoon)
 			self:DelayedWarningSign(timer.counterspellFirstCd - 1, icon.counterspell, timer.counterspellSoon + 1)
 			self:DelayedMessage(timer.counterspellFirstCd - 1, L["msg_counterspellSoon"], "Attention", false, nil, false)
@@ -212,7 +262,7 @@ function module:Counterspell()
 	
 	self:Bar(L["bar_counterspellCd"], timer.counterspellCd, icon.counterspell, true, color.counterspellCd)
 	
-	if not (UnitClass("Player") == "Warrior" or UnitClass("Player") == "Rogue" or UnitClass("Player") == "Hunter") then
+	if not (UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Hunter"]) then
 		self:Message(L["msg_counterspell"], "Positive", false, nil, false)
 		self:Sound("BikeHorn")
 		
@@ -226,7 +276,7 @@ end
 function module:Curse()
 	self:Bar(L["bar_curseCd"], timer.curseCd, icon.curse, true, color.curseCd)
 	
-	if UnitClass("Player") == "Mage" or UnitClass("Player") == "Druid" then
+	if UnitClass("Player") == BC["Mage"] or UnitClass("Player") == BC["Druid"] then
 		self:Message(L["msg_curse"], "Important", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.curse, 0.7)
@@ -236,7 +286,7 @@ end
 function module:Deaden()
 	self:RemoveBar(L["bar_deadenCd"])
 	
-	if UnitClass("Player") == "Shaman" or UnitClass("Player") == "Priest" then
+	if UnitClass("Player") == BC["Shaman"] or UnitClass("Player") == BC["Priest"] then
 		self:Message(L["msg_deaden"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.deaden, timer.deadenDur)
@@ -263,13 +313,13 @@ end
 function module:CheckBlink()
 	--define current shazzTarget first
 	if shazzTarget == nil then
-		if UnitName("Target") == "Shazzrah" then
+		if UnitName("Target") == L["c_shazzrah"] then
 			if UnitName("TargetTarget") ~= nil then
 				shazzTarget = UnitName("TargetTarget")
 			end
 		else 
 			for i=1,GetNumRaidMembers() do
-				if UnitName("raid"..i.."Target") == "Shazzrah" then
+				if UnitName("raid"..i.."Target") == L["c_shazzrah"] then
 					if UnitName("TargetTarget") ~= nil then
 						shazzTarget = UnitName("TargetTarget")
 						break
@@ -280,13 +330,13 @@ function module:CheckBlink()
 	
 	--then check for target change, if changed, guessing it's a blink
 	else
-		if UnitName("Target") == "Shazzrah" and UnitName("TargetTarget") ~= nil then
+		if UnitName("Target") == L["c_shazzrah"] and UnitName("TargetTarget") ~= nil then
 			if shazzTarget ~= UnitName("TargetTarget") then
 				self:Sync(syncName.blink)
 			end
 		else 
 			for i=1,GetNumRaidMembers() do
-				if UnitName("raid"..i.."Target") == "Shazzrah" and UnitName("raid"..i.."TargetTarget") ~= nil then
+				if UnitName("raid"..i.."Target") == L["c_shazzrah"] and UnitName("raid"..i.."TargetTarget") ~= nil then
 					if shazzTarget ~= UnitName("raid"..i.."TargetTarget") then
 						self:Sync(syncName.blink)
 						break

--- a/Raids/MC/Sulfuron.lua
+++ b/Raids/MC/Sulfuron.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Sulfuron Harbinger", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30078
 module.enabletrigger = module.translatedName
@@ -61,6 +62,67 @@ L:RegisterTranslations("enUS", function() return {
 	msg_immolate = "Immolate - Dispel!",
 	
 	msg_addDead = "/4 Flamewaker Protectors Dead",
+	c_flamewakerpriest = "Flamewaker Priest",
+} end)
+
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "Sulfuron",
+
+	knockback_cmd = "knockback",
+	knockback_name = "拉格纳罗斯之手警报",
+	knockback_desc = "拉格纳罗斯之手出现时进行警告",
+
+	heal_cmd = "heal",
+	heal_name = "黑暗治疗警报",
+	heal_desc = "黑暗治疗出现时进行警告",
+	
+	flamespear_cmd = "flamespear",
+	flamespear_name = "烈焰之矛警报",
+	flamespear_desc = "烈焰之矛出现时进行警告",
+	
+	inspire_cmd = "inspire",
+	inspire_name = "灵感警报",
+	inspire_desc = "灵感出现时进行警告",
+	
+	shadowwordpain_cmd = "shadowwordpain",
+	shadowwordpain_name = "暗言术：痛警报",
+	shadowwordpain_desc = "暗言术：痛出现时进行警告",
+	
+	immolate_cmd = "immolate",
+	immolate_name = "献祭警报",
+	immolate_desc = "献祭出现时进行警告",
+	
+	adds_cmd = "adds",
+	adds_name = "小怪死亡警报",
+	adds_desc = "小怪死亡时进行警告",
+	
+	
+	trigger_handOfRagnaros = "受到了拉格纳罗斯之手效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	bar_handOfRagnarosCd = "拉格纳罗斯之手冷却",
+	bar_handOfRagnarosDur = "拉格纳罗斯之手昏迷",
+	
+	trigger_darkMending = "烈焰行者祭司开始施放黑暗治疗。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF
+	bar_darkMending = "黑暗治疗",
+	msg_darkMending = "黑暗治疗 - 打断！",
+	
+	trigger_flameSpear = "萨弗隆先驱者开始施展烈焰之矛。", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	bar_flameSpearCd = "烈焰之矛冷却",
+	bar_flameSpearCast = "烈焰之矛！",
+	
+	trigger_inspire = "获得了灵感的效果。", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
+	bar_inspireDur = "灵感",
+	msg_inspire = "灵感 - 攻击速度+100% & 伤害+25%",
+	
+	trigger_shadowWordPain = "(.+)受到了暗言术：痛效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	msg_shadowWordPain = "暗言术：痛 - 驱散！",
+	
+	trigger_immolate = "(.+)受到了献祭效果的影响。", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
+	msg_immolate = "献祭 - 驱散！",
+	
+	msg_addDead = "/4 烈焰行者护卫死亡",
+	c_flamewakerpriest = "烈焰行者祭司",
 } end)
 
 local timer = {
@@ -154,7 +216,7 @@ end
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	BigWigs:CheckForBossDeath(msg, self)
 
-	if (msg == string.format(UNITDIESOTHER, "Flamewaker Priest")) then
+	if (msg == string.format(UNITDIESOTHER, L["c_flamewakerpriest"])) then
 		addDead = addDead + 1
 		if addDead <= 4 then
 			self:Sync(syncName.addDead .. " " .. addDead)
@@ -231,7 +293,7 @@ end
 function module:DarkMending()
 	self:Bar(L["bar_darkMending"], timer.darkMendingCast, icon.darkMending, true, color.darkMendingCast)
 	
-	if UnitClass("Player") == "Rogue" or UnitClass("Player") == "Warrior" or UnitClass("Player") == "Mage" then
+	if UnitClass("Player") == BC["Rogue"] or UnitClass("Player") == BC["Warrior"] or UnitClass("Player") == BC["Mage"] then
 		self:Message(L["msg_darkMending"], "Urgent", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.darkMending, 0.7)
@@ -251,7 +313,7 @@ function module:Inspire()
 end
 
 function module:ShadowWordPain()
-	if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 		self:Message(L["msg_shadowWordPain"], "Important", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.shadowWordPain, 0.7)
@@ -259,7 +321,7 @@ function module:ShadowWordPain()
 end
 
 function module:Immolate()
-	if UnitClass("Player") == "Priest" or UnitClass("Player") == "Paladin" then
+	if UnitClass("Player") == BC["Priest"] or UnitClass("Player") == BC["Paladin"] then
 		self:Message(L["msg_immolate"], "Important", false, nil, false)
 		self:Sound("Info")
 		self:WarningSign(icon.immolate, 0.7)

--- a/Raids/MC/Surger.lua
+++ b/Raids/MC/Surger.lua
@@ -1,5 +1,6 @@
 
 local module, L = BigWigs:ModuleDeclaration("Lava Surger", "Molten Core")
+local BC = AceLibrary("Babble-Class-2.2")
 
 module.revision = 30073
 module.enabletrigger = module.translatedName
@@ -24,6 +25,22 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_surge = "Lava Surger's Surge hits (.+) for", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
 	msg_surge = " failed to stack on the Surger",
 	msg_surgeYou = "S T A C K on the Surger",
+	you = "you",
+} end )
+L:RegisterTranslations("zhCN", function() return {
+	-- Wind汉化修复Turtle-WOW中文数据
+	-- Last update: 2024-06-22
+	cmd = "LavaSurger",
+
+	surge_cmd = "surge",
+	surge_name = "汹涌警报",
+	surge_desc = "汹涌出现时进行警告",
+	
+	
+	trigger_surge = "熔岩奔腾者的汹涌击中(.+)造成", --CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE
+	msg_surge = " 离石头人太远！",
+	msg_surgeYou = "快和石头人重叠站位！",
+	you = "你",
 } end )
 
 local timer = {
@@ -60,7 +77,7 @@ end
 function module:Event(msg)
 	if string.find(msg, L["trigger_surge"]) then
 		local _,_, surgePerson, _ = string.find(msg, L["trigger_surge"])
-		if surgePerson == "you" then surgePerson = UnitName("Player") end
+		if surgePerson == L["you"] then surgePerson = UnitName("Player") end
 		self:Sync(syncName.surge.. " ".. surgePerson)
 	end
 end

--- a/Raids/MC/Thaurissan.lua
+++ b/Raids/MC/Thaurissan.lua
@@ -44,6 +44,42 @@ L:RegisterTranslations("enUS", function() return {
 	warn_combustion = "GET_IN",
 } end)
 
+L:RegisterTranslations("zhCN", function() return {
+	cmd = "Thaurissan",
+
+	runetimers_cmd = "runetimers",
+	runetimers_name = "符文计时",
+	runetimers_desc = "提示即将到来的和正在生效的爆炸符文与燃烧符文",
+
+	runeofdetonation_cmd = "runeofdetonation",
+	runeofdetonation_name = "爆炸符文警报",
+	runeofdetonation_desc = "当你同时拥有爆炸符文和力量符文时给出个人警报",
+
+	runeofcombustion_cmd = "runeofcombustion",
+	runeofcombustion_name = "燃烧符文警报",
+	runeofcombustion_desc = "当你拥有燃烧符文且没有力量符文时给出个人警报",
+
+	trigger_detonation = "受到了爆炸符文效果的影响",
+	trigger_combustion = "受到了燃烧符文效果的影响",
+	trigger_you = "你受到了",
+	trigger_runeOfDetonationFade = "爆炸符文效果从你身上消失了",
+	trigger_runeOfCombustionFade = "燃烧符文效果从你身上消失了",
+
+	trigger_runeOfPowerYou = "你受到了力量符文效果的影响",
+	trigger_runeOfPowerFade = "力量符文效果从你身上消失了",
+
+	msg_detonation = "离开符文圈 - 爆炸符文",
+	msg_combustion = "留在符文圈内 - 燃烧符文",
+	msg_combustion_out_of_zone = "快回到符文圈里！",
+	msg_detonation_in_zone = "快离开符文圈！",
+	bar_runeDetonation = "爆炸符文（出去）",
+	bar_runeCombustion = "燃烧符文（进来）",
+	bar_detonationNext = "下一个爆炸符文",
+	bar_combustionNext = "下一个燃烧符文",
+	warn_detonation = "出去",
+	warn_combustion = "进来",
+} end)
+
 local hasRuneOfDetonation = false
 local hasRuneOfPower = false
 local hasRuneOfCombustion = false


### PR DESCRIPTION
## Summary

This PR adds zhCN localization support for Molten Core and Blackwing Lair modules.

The changes are intentionally kept narrow:
- add missing zhCN localization strings for MC/BWL modules
- add locale-safe comparisons where boss/class/player-name matching would otherwise depend on enUS text
- fix a few zhCN-specific trigger/message mismatches found during review

## Scope

Included:
- MC/BWL zhCN localization updates
- minimal locale-safe fixes such as `L["you"]`, localized boss/add names, and `Babble-Class` usage where needed
- localized SAY text that was previously hardcoded

Not included:
- broad module rewrites
- unrelated feature changes
