### PR TITLE
(TMH) add Timbermaw Hold raid modules

### DIFF
--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -225,6 +225,13 @@ Raids\EmeraldSanctum\SanctumSupressor.lua
 Raids\EmeraldSanctum\SanctumWyrmkin.lua
 Raids\EmeraldSanctum\SanctumWyrm.lua
 
+Raids\TMH\Karrsh.lua
+Raids\TMH\Kronn.lua
+Raids\TMH\Loktanag.lua
+Raids\TMH\Partath.lua
+Raids\TMH\Ormanos.lua
+Raids\TMH\Rotgrowl.lua
+
 Raids\Karazhan\LordBlackwaldII.lua
 Raids\Karazhan\BroodQueenAraxxna.lua
 Raids\Karazhan\Grizikil.lua

--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
 
-## X-Revision: 30137
+## X-Revision: 30138
 ## X-Fork: Pepo
-## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30137|r |cffabd473Turtle-WoW|r
+## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30138|r |cffabd473Turtle-WoW|r
 ## Title-zhCN: |cffabd473Turtle-WoW|r Big Wigs
 ## Notes: Boss Mods with Timer bars.
 ## Notes-esES: Módulos para Jefes con barras temporizadoras.

--- a/Core.lua
+++ b/Core.lua
@@ -75,6 +75,7 @@ L:RegisterTranslations("enUS", function()
 		["Dire Maul"] = "DireMaul",
 		["Blackrock Spire"] = "BlackrockSpire",
 		["The Black Morass"] = "BlackMorass",
+		["Timbermaw Hold"] = "TMH",
 		["Silithus"] = true,
 		["Outdoor Raid Bosses"] = "Outdoor",
 		["Outdoor Raid Bosses Zone"] = "Outdoor Raid Bosses", -- DO NOT EVER TRANSLATE untill I find a more elegant option
@@ -1148,7 +1149,7 @@ function BigWigs:ModuleDeclaration(bossName, zoneName)
 
 
 	-- zone
-	local raidZones = { "Blackwing Lair", "Ruins of Ahn'Qiraj", "Ahn'Qiraj", "Molten Core", "Naxxramas", "Emerald Sanctum", "Zul'Gurub" }
+	local raidZones = { "Blackwing Lair", "Ruins of Ahn'Qiraj", "Ahn'Qiraj", "Molten Core", "Naxxramas", "Emerald Sanctum", "Zul'Gurub", "Timbermaw Hold" }
 	local isOutdoorraid = true
 	for i, value in ipairs(raidZones) do
 		if value == zoneName then

--- a/Libs/Babble-Boss-2.2/Babble-Boss-2.2.lua
+++ b/Libs/Babble-Boss-2.2/Babble-Boss-2.2.lua
@@ -10,7 +10,7 @@ Dependencies: AceLibrary, AceLocale-2.2
 ]]
 
 local MAJOR_VERSION = "Babble-Boss-2.2"
-local MINOR_VERSION = 20007
+local MINOR_VERSION = 20008
 
 if not AceLibrary then error(MAJOR_VERSION .. " requires AceLibrary") end
 
@@ -52,6 +52,14 @@ BabbleBoss:RegisterTranslations("enUS", function()
 		["Sanctum Wyrmkin"] = true,
 		["Sanctum Wyrm"] = true,
 		["Solnius"] = true,
+		["Karrsh the Sentinel"] = true,
+		["Rotgrowl"] = true,
+		["Kodiak"] = true,
+		["Ormanos the Cracked"] = true,
+		["Chieftain Partath"] = true,
+		["Loktanag the Vile"] = true,
+		["Archdruid Kronn"] = true,
+		["Dreamform of Kronn"] = true,
 		["Erennius"] = true,
 		["Dark Rider Champion"] = true,
 		["Lord Blackwald II"] = true,

--- a/Raids/KarazhanUpper/Anomalus.lua
+++ b/Raids/KarazhanUpper/Anomalus.lua
@@ -377,7 +377,7 @@ function module:UpdateManaboundStatusFrame()
 			tile = true,
 			tileSize = 16,
 			edgeSize = 16,
-			insets = { left = 8, right = 8, top = 8, bottom = 8 }
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
 		})
 		self.manaboundStatusFrame:SetBackdropColor(0, 0, 0, 1)
 

--- a/Raids/KarazhanUpper/KeeperGnarlmoon.lua
+++ b/Raids/KarazhanUpper/KeeperGnarlmoon.lua
@@ -458,7 +458,7 @@ function module:UpdateOwlStatusFrame()
 			tile = true,
 			tileSize = 16,
 			edgeSize = 16,
-			insets = { left = 8, right = 8, top = 8, bottom = 8 }
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
 		})
 		self.owlStatusFrame:SetBackdropColor(0, 0, 0, 1)
 

--- a/Raids/Naxxramas/Horsemen.lua
+++ b/Raids/Naxxramas/Horsemen.lua
@@ -385,7 +385,7 @@ function module:UpdateBossStatusFrame()
 			tile = true,
 			tileSize = 16,
 			edgeSize = 16,
-			insets = { left = 8, right = 8, top = 8, bottom = 8 }
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
 		})
 		self.bossStatusFrame:SetBackdropColor(0, 0, 0, 1)
 

--- a/Raids/Naxxramas/Thaddius.lua
+++ b/Raids/Naxxramas/Thaddius.lua
@@ -342,7 +342,7 @@ function module:UpdateTankStatusFrame()
 			tile = true,
 			tileSize = 16,
 			edgeSize = 16,
-			insets = { left = 8, right = 8, top = 8, bottom = 8 }
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
 		})
 		self.tankStatusFrame:SetBackdropColor(0, 0, 0, 1)
 

--- a/Raids/TMH/Karrsh.lua
+++ b/Raids/TMH/Karrsh.lua
@@ -1,0 +1,238 @@
+
+local module, L = BigWigs:ModuleDeclaration("Karrsh the Sentinel", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = module.translatedName
+module.toggleoptions = {"roar", "seed", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Karrsh",
+
+	roar_cmd = "roar",
+	roar_name = "Furious Roar Alert",
+	roar_desc = "Timer for Karrsh's Furious Roar while Spear of Timbermaw is active",
+
+	seed_cmd = "seed",
+	seed_name = "Seed of Corruption Alert",
+	seed_desc = "Warn when someone is afflicted by Seed of Corruption and mark them",
+
+	trigger_spearGain = "Karrsh the Sentinel gains Spear of Timbermaw",
+	trigger_spearFade = "Spear of Timbermaw fades from Karrsh the Sentinel",
+	trigger_roarCast = "Karrsh the Sentinel casts Furious Roar",
+
+	trigger_seedYou = "You are afflicted by Seed of Corruption",
+	trigger_seedOther = "(.+) is afflicted by Seed of Corruption",
+	trigger_seedFadeYou = "Seed of Corruption fades from you",
+	trigger_seedFadeOther = "Seed of Corruption fades from (.+)%.",
+
+	bar_roar = "Furious Roar",
+	msg_roarSoon = "Threat drop incoming!",
+
+	msg_seedYou = "SEED ON YOU - GET AWAY FROM OTHERS!",
+} end )
+
+local timer = {
+	roar = 12,
+}
+
+local icon = {
+	roar = "Ability_Druid_DemoralizingRoar",
+	seed = "ability_warlock_shadowflame",
+}
+
+local color = {
+	roar = "Red",
+	seed = "Purple",
+}
+
+local syncName = {
+	spearGain = "KarrshSpearGain"..module.revision,
+	spearFade = "KarrshSpearFade"..module.revision,
+	roar = "KarrshRoar"..module.revision,
+	seedGain = "KarrshSeedGain"..module.revision,
+	seedFade = "KarrshSeedFade"..module.revision,
+}
+
+function module:OnEnable()
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Event")
+
+	self:ThrottleSync(5, syncName.spearGain)
+	self:ThrottleSync(5, syncName.spearFade)
+	self:ThrottleSync(5, syncName.roar)
+	-- per-target payloads; dedupe is handled by self.seedTargets so any
+	-- throttle here would drop syncs for different players sharing the key
+	self:ThrottleSync(0, syncName.seedGain)
+	self:ThrottleSync(0, syncName.seedFade)
+end
+
+function module:OnSetup()
+	self.seedTargets = {}
+end
+function module:OnEngage()
+	self.seedTargets = {}
+end
+function module:OnDisengage()
+	self:RemoveBar(L["bar_roar"])
+	-- Framework auto-restores initialPlayerMarks on disengage (Core.lua:484-488),
+	-- so seeds left applied will revert to the raid's original marks automatically.
+	self.seedTargets = {}
+end
+
+function module:Event(msg)
+	if string.find(msg, L["trigger_spearGain"]) then
+		self:Sync(syncName.spearGain)
+		return
+	elseif string.find(msg, L["trigger_spearFade"]) then
+		self:Sync(syncName.spearFade)
+		return
+	elseif string.find(msg, L["trigger_roarCast"]) then
+		self:Sync(syncName.roar)
+		return
+	end
+
+	-- Seed of Corruption gains
+	if string.find(msg, L["trigger_seedYou"]) then
+		self:Sync(syncName.seedGain.." "..UnitName("player"))
+		return
+	end
+	local _, _, target = string.find(msg, L["trigger_seedOther"])
+	if target then
+		self:Sync(syncName.seedGain.." "..target)
+		return
+	end
+
+	-- Seed of Corruption fades
+	if string.find(msg, L["trigger_seedFadeYou"]) then
+		self:Sync(syncName.seedFade.." "..UnitName("player"))
+		return
+	end
+	local _, _, fadeTarget = string.find(msg, L["trigger_seedFadeOther"])
+	if fadeTarget then
+		self:Sync(syncName.seedFade.." "..fadeTarget)
+		return
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.spearGain and self.db.profile.roar then
+		self:StartRoarBar()
+	elseif sync == syncName.roar and self.db.profile.roar then
+		self:StartRoarBar()
+	elseif sync == syncName.spearFade then
+		self:RemoveBar(L["bar_roar"])
+	elseif sync == syncName.seedGain and rest and self.db.profile.seed then
+		self:SeedGain(rest)
+	elseif sync == syncName.seedFade and rest and self.db.profile.seed then
+		self:SeedFade(rest)
+	end
+end
+
+function module:StartRoarBar()
+	self:RemoveBar(L["bar_roar"])
+	self:CancelDelayedMessage(L["msg_roarSoon"])
+	-- pass otherc=nil so BigWigsColors drives the time-based gradient
+	self:Bar(L["bar_roar"], timer.roar, icon.roar)
+	-- fire the warning only in the final 3 seconds
+	self:DelayedMessage(timer.roar - 4, L["msg_roarSoon"], "Important", false, "Alert")
+end
+
+function module:SeedGain(target)
+	if self.seedTargets[target] then return end
+	self.seedTargets[target] = true
+
+	if target == UnitName("player") then
+		self:Message(L["msg_seedYou"], "Personal", true, "Alarm")
+		self:WarningSign(icon.seed, 3, true)
+	end
+
+	local mark = self:GetAvailableRaidMark()
+	if mark then
+		self:SetRaidTargetForPlayer(target, mark)
+	end
+end
+
+function module:SeedFade(target)
+	if not self.seedTargets[target] then return end
+	self.seedTargets[target] = nil
+	self:RestorePreviousRaidTargetForPlayer(target)
+end
+
+-- Spoofs real combat-log strings through Event() so the full parse -> sync
+-- -> handler chain is exercised. Requires the player to be in a raid for
+-- Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Karrsh the Sentinel"); BigWigs:SetupModule("Karrsh the Sentinel"); m:Test();
+function module:Test()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+	self:Message("Karrsh test started", "Positive")
+
+	local spearGainMsg = "Karrsh the Sentinel gains Spear of Timbermaw (1)."
+	local roarMsg      = "Karrsh the Sentinel casts Furious Roar(33039) on Karrsh the Sentinel."
+	local spearFadeMsg = "Spear of Timbermaw fades from Karrsh the Sentinel."
+
+	self:ScheduleEvent("KarrshTestSpearGain", self.Event, 2,  self, spearGainMsg)
+	self:ScheduleEvent("KarrshTestRoar1",     self.Event, 14, self, roarMsg)
+	self:ScheduleEvent("KarrshTestRoar2",     self.Event, 26, self, roarMsg)
+	self:ScheduleEvent("KarrshTestRoar3",     self.Event, 38, self, roarMsg)
+
+	-- Spoof spear fade 6s into the 4th bar so we can verify the active bar
+	-- gets cut off (not just expiring naturally).
+	self:ScheduleEvent("KarrshTestSpearFade", self.Event, 44, self, spearFadeMsg)
+	self:ScheduleEvent("KarrshTestDone", function()
+		module:Message("Karrsh test complete", "Positive")
+	end, 46)
+	return true
+end
+
+-- Simulates Seed of Corruption on multiple targets to exercise the rotating
+-- mark allocator. Picks up to 3 random raid members (falls back to the player
+-- if solo), fires gains staggered 2s apart, then fades them one by one.
+-- Usage: /run local m=BigWigs:GetModule("Karrsh the Sentinel"); BigWigs:SetupModule("Karrsh the Sentinel"); m:TestSeed();
+function module:TestSeed()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+
+	local pool = {}
+	local n = GetNumRaidMembers()
+	if n > 0 then
+		for i = 1, n do
+			local name = UnitName("raid"..i)
+			if name then table.insert(pool, name) end
+		end
+	else
+		table.insert(pool, UnitName("player"))
+	end
+
+	-- Shuffle-pick up to 3
+	local targets = {}
+	for _ = 1, 3 do
+		if table.getn(pool) == 0 then break end
+		local idx = math.random(1, table.getn(pool))
+		table.insert(targets, pool[idx])
+		table.remove(pool, idx)
+	end
+
+	self:Message("Seed test targets: "..table.concat(targets, ", "), "Positive")
+
+	for i, target in ipairs(targets) do
+		local gainMsg = target.." is afflicted by Seed of Corruption (1)."
+		local fadeMsg = "Seed of Corruption fades from "..target.."."
+		self:ScheduleEvent("KarrshTestSeedGain"..i, self.Event, 1 + (i - 1) * 2, self, gainMsg)
+		self:ScheduleEvent("KarrshTestSeedFade"..i, self.Event, 10 + (i - 1) * 2, self, fadeMsg)
+	end
+
+	self:ScheduleEvent("KarrshTestSeedEnd", function()
+		module:Message("Seed test complete", "Positive")
+	end, 10 + table.getn(targets) * 2 + 1)
+	return true
+end

--- a/Raids/TMH/Kronn.lua
+++ b/Raids/TMH/Kronn.lua
@@ -1,0 +1,391 @@
+
+local module, L = BigWigs:ModuleDeclaration("Archdruid Kronn", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = {
+	"Archdruid Kronn",
+	"Dreamform of Kronn",
+}
+module.toggleoptions = {"hpframe", "dreamfever", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+module.defaultDB = {
+	hpframe = true,
+	-- hpframeposx / hpframeposy computed in UpdateHpFrame on first frame
+	-- creation so GetScreenWidth/Height return real values (they can be
+	-- unreliable at file-load time).
+}
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Kronn",
+
+	hpframe_cmd = "hpframe",
+	hpframe_name = "HP Frame",
+	hpframe_desc = "Shows a frame with the HP of Archdruid Kronn and Dreamform of Kronn",
+
+	kronn_name = "Kronn to |cffffff00kill|r",
+	dream_name = "Dream to |cff00ff00fill|r",
+
+	kronn_zero = "DEAD",
+	dream_zero = "WAKING",
+
+	frame_title = "Kronn HP",
+
+	trigger_victory = "The Nightmare has ended!",
+
+	dreamfever_cmd = "dreamfever",
+	dreamfever_name = "Dream Fever Alert",
+	dreamfever_desc = "Warn when someone is afflicted by Dream Fever and mark them",
+
+	trigger_feverYou = "You are afflicted by Dream Fever",
+	trigger_feverOther = "(.+) is afflicted by Dream Fever",
+	trigger_feverFadeYou = "Dream Fever fades from you",
+	trigger_feverFadeOther = "Dream Fever fades from (.+)%.",
+
+	msg_feverYou = "DREAM FEVER ON YOU - GET AWAY FROM OTHERS!",
+	msg_feverOther = "Dream Fever on %s - get away from them!",
+} end )
+
+local realKronn = "Archdruid Kronn"
+local dreamKronn = "Dreamform of Kronn"
+
+local icon = {
+	fever = "Spell_Nature_NullifyDisease",
+}
+
+local syncName = {
+	kronnHp = "KronnHp"..module.revision,
+	dreamHp = "KronnDreamHp"..module.revision,
+	feverGain = "KronnFeverGain"..module.revision,
+	feverFade = "KronnFeverFade"..module.revision,
+}
+
+function module:OnSetup()
+	self.kronnHp = 100
+	self.dreamHp = 0 -- raw HP percent; display is 100 - dreamHp to show "distance to full"
+	self.feverTargets = {}
+end
+
+function module:OnEnable()
+	-- Core.lua fires OnEnable *before* OnSetup, so initialize HP values here
+	-- to avoid nil concat in UpdateHpFrame below.
+	self.kronnHp = 100
+	self.dreamHp = 0
+	self.feverTargets = {}
+
+	self:ThrottleSync(2, syncName.kronnHp)
+	self:ThrottleSync(2, syncName.dreamHp)
+	-- per-target payloads; dedupe is handled by self.feverTargets so any
+	-- throttle here would drop syncs for different players sharing the key
+	self:ThrottleSync(0, syncName.feverGain)
+	self:ThrottleSync(0, syncName.feverFade)
+	self:RegisterEvent("UNIT_HEALTH")
+	self:RegisterEvent("UPDATE_MOUSEOVER_UNIT")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "AfflictionEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "AfflictionEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "AfflictionEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "FadeEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "FadeEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "FadeEvent")
+	if self.db.profile.hpframe then
+		self:UpdateHpFrame()
+		self.hpFrame:Show() -- allow positioning before pull
+	end
+end
+
+function module:OnEngage()
+	self.kronnHp = 100
+	self.dreamHp = 0
+	self.victorySent = nil
+	self.feverTargets = {}
+
+	if self.db.profile.hpframe then
+		self:UpdateHpFrame()
+		self.hpFrame:Show()
+	end
+end
+
+function module:OnDisengage()
+	-- Framework auto-restores initialPlayerMarks on disengage (Core.lua:484-488)
+	self.feverTargets = {}
+end
+
+function module:AfflictionEvent(msg)
+	if string.find(msg, L["trigger_feverYou"]) then
+		self:Sync(syncName.feverGain.." "..UnitName("player"))
+		return
+	end
+	local _, _, target = string.find(msg, L["trigger_feverOther"])
+	if target then
+		self:Sync(syncName.feverGain.." "..target)
+	end
+end
+
+function module:FadeEvent(msg)
+	if string.find(msg, L["trigger_feverFadeYou"]) then
+		self:Sync(syncName.feverFade.." "..UnitName("player"))
+		return
+	end
+	local _, _, target = string.find(msg, L["trigger_feverFadeOther"])
+	if target then
+		self:Sync(syncName.feverFade.." "..target)
+	end
+end
+
+function module:UNIT_HEALTH(unit)
+	self:ScanUnit(unit)
+end
+
+function module:UPDATE_MOUSEOVER_UNIT()
+	self:ScanUnit("mouseover")
+end
+
+function module:ScanUnit(unit)
+	local name = UnitName(unit)
+	if not name then return end
+	if name == realKronn or name == dreamKronn then
+		-- Archdruid Kronn never actually dies; the fight ends when he becomes
+		-- non-hostile. Dreamform is always friendly, so only check real Kronn.
+		if name == realKronn and UnitExists(unit) and not UnitIsEnemy("player", unit) then
+			if self.engaged and not self.victorySent then
+				self.victorySent = true
+				self:SendBossDeathSync()
+			end
+			return
+		end
+
+		local h, m = UnitHealth(unit), UnitHealthMax(unit)
+		if h and m and m > 0 then
+			local pct = math.floor((h / m) * 100)
+			if name == realKronn then
+				self.kronnHp = pct
+				self:Sync(syncName.kronnHp.." "..pct)
+			else
+				self.dreamHp = pct
+				self:Sync(syncName.dreamHp.." "..pct)
+			end
+		end
+	end
+end
+
+function module:UpdateHpFrame()
+	if not self.db.profile.hpframe then return end
+
+	if not self.hpFrame then
+		local f = CreateFrame("Frame", "BigWigsKronnHpFrame", UIParent)
+		f.module = self
+		local frameW, frameH = 180, 80
+		f:SetWidth(frameW)
+		f:SetHeight(frameH)
+		local s = f:GetEffectiveScale()
+
+		-- Default to screen center if no saved position.
+		if not self.db.profile.hpframeposx or not self.db.profile.hpframeposy then
+			self.db.profile.hpframeposx = UIParent:GetWidth() / 2
+			self.db.profile.hpframeposy = UIParent:GetHeight() / 2
+		end
+
+		f:ClearAllPoints()
+		f:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT",
+			self.db.profile.hpframeposx / s - frameW / 2,
+			self.db.profile.hpframeposy / s + frameH / 2)
+		f:SetBackdrop({
+			bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+			edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+			tile = true, tileSize = 16, edgeSize = 16,
+			insets = { left = 4, right = 4, top = 4, bottom = 4 }
+		})
+		f:SetBackdropColor(0, 0, 0, 1)
+
+		f:SetMovable(true)
+		f:EnableMouse(true)
+		f:RegisterForDrag("LeftButton")
+		f:SetScript("OnDragStart", function() this:StartMoving() end)
+		f:SetScript("OnDragStop", function()
+			this:StopMovingOrSizing()
+			local sc = this:GetEffectiveScale()
+			this.module.db.profile.hpframeposx = this:GetLeft() * sc
+			this.module.db.profile.hpframeposy = this:GetTop() * sc
+		end)
+
+		local font = "Fonts\\FRIZQT__.TTF"
+		local fs = 12
+
+		f.title = f:CreateFontString(nil, "ARTWORK")
+		f.title:SetFontObject(GameFontNormal)
+		f.title:SetPoint("TOP", f, "TOP", 0, -10)
+		f.title:SetText(L["frame_title"])
+		f.title:SetFont(font, fs)
+
+		f.kronnLabel = f:CreateFontString(nil, "ARTWORK")
+		f.kronnLabel:SetPoint("TOPLEFT", f, "TOPLEFT", 15, -30)
+		f.kronnLabel:SetFont(font, fs)
+		f.kronnLabel:SetText(L["kronn_name"])
+		f.kronnLabel:SetTextColor(0.3, 1, 0.3)
+
+		f.kronnHpText = f:CreateFontString(nil, "ARTWORK")
+		f.kronnHpText:SetPoint("TOPRIGHT", f, "TOPRIGHT", -15, -30)
+		f.kronnHpText:SetFont(font, fs)
+
+		f.dreamLabel = f:CreateFontString(nil, "ARTWORK")
+		f.dreamLabel:SetPoint("TOPLEFT", f, "TOPLEFT", 15, -50)
+		f.dreamLabel:SetFont(font, fs)
+		f.dreamLabel:SetText(L["dream_name"])
+		f.dreamLabel:SetTextColor(0.5, 0.5, 1)
+
+		f.dreamHpText = f:CreateFontString(nil, "ARTWORK")
+		f.dreamHpText:SetPoint("TOPRIGHT", f, "TOPRIGHT", -15, -50)
+		f.dreamHpText:SetFont(font, fs)
+
+		self.hpFrame = f
+	end
+
+	self:SetHpText(self.hpFrame.kronnHpText, self.kronnHp, L["kronn_zero"])
+	self:SetHpText(self.hpFrame.dreamHpText, 100 - self.dreamHp, L["dream_zero"])
+end
+
+function module:SetHpText(fontString, pct, zeroLabel)
+	if not fontString then return end
+	local text = pct .. "%"
+	local r, g, b = 1, 1, 1
+	if pct <= 0 then
+		text = zeroLabel or "DEAD"
+		r, g, b = 0.5, 0.5, 0.5
+	elseif pct < 15 then
+		r, g, b = 1, 0, 0
+	elseif pct < 35 then
+		r, g, b = 1, 1, 0
+	end
+	fontString:SetText(text)
+	fontString:SetTextColor(r, g, b)
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if not rest then return end
+	if sync == syncName.kronnHp then
+		local n = tonumber(rest)
+		if n then
+			self.kronnHp = n
+			if self.db.profile.hpframe then
+				self:UpdateHpFrame()
+			end
+		end
+	elseif sync == syncName.dreamHp then
+		local n = tonumber(rest)
+		if n then
+			self.dreamHp = n
+			if self.db.profile.hpframe then
+				self:UpdateHpFrame()
+			end
+		end
+	elseif sync == syncName.feverGain and self.db.profile.dreamfever then
+		self:FeverGain(rest)
+	elseif sync == syncName.feverFade and self.db.profile.dreamfever then
+		self:FeverFade(rest)
+	end
+end
+
+function module:FeverGain(target)
+	if self.feverTargets[target] then return end
+	self.feverTargets[target] = true
+
+	if target == UnitName("player") then
+		self:Message(L["msg_feverYou"], "Personal", true, "Alarm")
+		self:WarningSign(icon.fever, 3, true)
+	else
+		self:Message(string.format(L["msg_feverOther"], target), "Urgent", false, "Alert")
+	end
+
+	local mark = self:GetAvailableRaidMark()
+	if mark then
+		self:SetRaidTargetForPlayer(target, mark)
+	end
+end
+
+function module:FeverFade(target)
+	if not self.feverTargets[target] then return end
+	self.feverTargets[target] = nil
+	self:RestorePreviousRaidTargetForPlayer(target)
+end
+
+-- Usage: /run local m=BigWigs:GetModule("Archdruid Kronn"); BigWigs:SetupModule("Archdruid Kronn"); m:Test();
+function module:Test()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+
+	if not self.db.profile.hpframe then
+		self.db.profile.hpframe = true
+	end
+	self:UpdateHpFrame()
+	self.hpFrame:Show()
+
+	self:Message("Archdruid Kronn test started", "Positive")
+
+	-- k = Kronn current HP (counting down toward 0)
+	-- d = Dream current HP (counting up toward 100)
+	local steps = {
+		{t = 1,  k = 95, d = 5  },
+		{t = 3,  k = 80, d = 15 },
+		{t = 5,  k = 65, d = 30 },
+		{t = 7,  k = 50, d = 45 },
+		{t = 9,  k = 40, d = 55 },
+		{t = 11, k = 32, d = 65 },
+		{t = 13, k = 20, d = 75 },
+		{t = 15, k = 12, d = 85 },
+		{t = 17, k = 5,  d = 92 },
+		{t = 19, k = 0,  d = 98 },
+		{t = 21, k = 0,  d = 100},
+	}
+	for i, e in ipairs(steps) do
+		local k, d = e.k, e.d
+		self:ScheduleEvent("KronnTestHp"..i, function()
+			module.kronnHp = k
+			module.dreamHp = d
+			module:UpdateHpFrame()
+		end, e.t)
+	end
+
+	self:ScheduleEvent("KronnTestEnd", function()
+		module.kronnHp = 100
+		module.dreamHp = 0
+		module:UpdateHpFrame()
+		module:Message("Archdruid Kronn test complete", "Positive")
+	end, 24)
+	return true
+end
+
+-- Picks a random raid member (falls back to the player if solo) and spoofs
+-- the real Dream Fever combat-log strings through AfflictionEvent / FadeEvent
+-- so the full parse -> sync -> handler chain is exercised. Requires the
+-- player to be in a raid for Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Archdruid Kronn"); BigWigs:SetupModule("Archdruid Kronn"); m:TestFever();
+function module:TestFever()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+
+	local target
+	local n = GetNumRaidMembers()
+	if n > 0 then
+		target = UnitName("raid"..math.random(1, n))
+	end
+	if not target then target = UnitName("player") end
+
+	self:Message("Dream Fever test target: "..target, "Positive")
+
+	local isSelf = target == UnitName("player")
+	local gainMsg = isSelf
+		and "You are afflicted by Dream Fever (1)."
+		or (target.." is afflicted by Dream Fever (1).")
+	local fadeMsg = isSelf
+		and "Dream Fever fades from you."
+		or ("Dream Fever fades from "..target..".")
+
+	self:ScheduleEvent("KronnTestFeverGain", self.AfflictionEvent, 2,  self, gainMsg)
+	self:ScheduleEvent("KronnTestFeverFade", self.FadeEvent,       12, self, fadeMsg)
+	self:ScheduleEvent("KronnTestFeverEnd", function()
+		module:Message("Dream Fever test complete", "Positive")
+	end, 14)
+	return true
+end

--- a/Raids/TMH/Loktanag.lua
+++ b/Raids/TMH/Loktanag.lua
@@ -1,0 +1,89 @@
+
+local module, L = BigWigs:ModuleDeclaration("Loktanag the Vile", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = module.translatedName
+module.toggleoptions = {"secretion", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Loktanag",
+
+	secretion_cmd = "secretion",
+	secretion_name = "Infected Secretion Alert",
+	secretion_desc = "Timer for Loktanag the Vile's Infected Secretion",
+
+	trigger_secretion = "Loktanag the Vile casts Infected Secretion",
+	bar_secretion = "Infected Secretion",
+} end )
+
+local timer = {
+	secretion = {12, 14},
+}
+local icon = {
+	secretion = "Spell_Nature_NullifyDisease",
+}
+local color = {
+	secretion = "Green",
+}
+local syncName = {
+	secretion = "LoktanagSecretion"..module.revision,
+}
+
+function module:OnEnable()
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Event")
+
+	self:ThrottleSync(5, syncName.secretion)
+end
+
+function module:OnSetup()
+end
+
+function module:OnEngage()
+	-- first Infected Secretion lands ~2.4-4.9s after engage; wait for the
+	-- actual cast to start the interval bar
+end
+
+function module:OnDisengage()
+end
+
+function module:Event(msg)
+	if string.find(msg, L["trigger_secretion"]) then
+		self:Sync(syncName.secretion)
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.secretion and self.db.profile.secretion then
+		self:Secretion()
+	end
+end
+
+function module:Secretion()
+	self:RemoveBar(L["bar_secretion"])
+	self:IntervalBar(L["bar_secretion"], timer.secretion[1], timer.secretion[2], icon.secretion, true, color.secretion)
+end
+
+-- Spoofs real combat-log strings through Event() so the full parse -> sync
+-- -> handler chain is exercised. Requires the player to be in a raid for
+-- Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Loktanag the Vile"); BigWigs:SetupModule("Loktanag the Vile"); m:Test();
+function module:Test()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+	self:Message("Loktanag the Vile test started", "Positive")
+
+	local castMsg = "Loktanag the Vile casts Infected Secretion(52813) on "..UnitName("player").."."
+	for i = 1, 5 do
+		self:ScheduleEvent("LoktanagTestSecretion"..i, self.Event, i * 12.5, self, castMsg)
+	end
+
+	self:ScheduleEvent("LoktanagTestEnd", function()
+		module:RemoveBar(L["bar_secretion"])
+		module:Message("Loktanag the Vile test complete", "Positive")
+	end, 5 * 12.5 + 3)
+	return true
+end

--- a/Raids/TMH/Ormanos.lua
+++ b/Raids/TMH/Ormanos.lua
@@ -1,0 +1,124 @@
+
+local module, L = BigWigs:ModuleDeclaration("Ormanos the Cracked", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = module.translatedName
+module.toggleoptions = {"charge", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Ormanos",
+
+	charge_cmd = "charge",
+	charge_name = "Charge Alert",
+	charge_desc = "Warns when Ormanos prepares to charge a player (boulder throw)",
+
+	trigger_charge = "Ormanos is preparing to charge (.+)!",
+	trigger_chargeLand = "Rampaging Earth",
+
+	msg_chargeYou = "CHARGE ON YOU - STACK WITH RANGED!",
+} end )
+
+local icon = {
+	charge = "Ability_Warrior_Charge",
+}
+
+local syncName = {
+	charge     = "OrmanosCharge"..module.revision,
+	chargeLand = "OrmanosChargeLand"..module.revision,
+}
+
+function module:OnEnable()
+	self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE", "Emote")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "LandEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "LandEvent")
+	self:ThrottleSync(3, syncName.charge)
+	self:ThrottleSync(1, syncName.chargeLand)
+end
+
+function module:OnSetup()
+	self.markedTarget = nil
+end
+function module:OnEngage() end
+function module:OnDisengage()
+	-- Framework auto-restores initialPlayerMarks on disengage (Core.lua:484-488)
+	self.markedTarget = nil
+end
+
+function module:Emote(msg)
+	local _, _, target = string.find(msg, L["trigger_charge"])
+	if target then
+		self:Sync(syncName.charge.." "..target)
+	end
+end
+
+function module:LandEvent(msg)
+	if self.markedTarget and string.find(msg, L["trigger_chargeLand"]) then
+		-- broadcast so the raid leader (possibly not the seer of this msg)
+		-- is the one that actually calls SetRaidTarget to restore
+		self:Sync(syncName.chargeLand.." "..self.markedTarget)
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.charge and rest and self.db.profile.charge then
+		self:Charge(rest)
+	elseif sync == syncName.chargeLand and rest then
+		if self.markedTarget == rest then
+			self:RestorePreviousRaidTargetForPlayer(rest)
+			self.markedTarget = nil
+		end
+	end
+end
+
+function module:Charge(target)
+	if target == UnitName("player") then
+		self:Message(L["msg_chargeYou"], "Personal", true, "Alarm")
+		self:WarningSign(icon.charge, 3, true)
+	end
+
+	if self.markedTarget and self.markedTarget ~= target then
+		self:RestorePreviousRaidTargetForPlayer(self.markedTarget)
+	end
+	self.markedTarget = target
+	self:SetRaidTargetForPlayer(target, 8) -- Skull
+end
+
+-- Spoofs real combat-log strings through Emote() and LandEvent() so the full
+-- parse -> sync -> handler chain is exercised. Requires the player to be in a
+-- raid for Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Ormanos the Cracked"); BigWigs:SetupModule("Ormanos the Cracked"); m:Test();
+function module:Test()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+	self:Message("Ormanos test started", "Positive")
+
+	local player = UnitName("player")
+
+	-- pick a second target from the raid (any raid member other than player)
+	local other
+	for i = 1, GetNumRaidMembers() do
+		local name = UnitName("raid"..i)
+		if name and name ~= player then
+			other = name
+			break
+		end
+	end
+	if not other then other = player end -- solo fallback: both charges on player
+
+	-- first charge: on you
+	self:ScheduleEvent("OrmanosTestChargeYou", self.Emote, 2, self,
+		"Ormanos is preparing to charge "..player.."!")
+	self:ScheduleEvent("OrmanosTestLandYou", self.LandEvent, 6, self,
+		"Ormanos the Cracked 's Rampaging Earth hits "..player.." for 2500 Nature damage.")
+
+	-- second charge: on another raid member
+	self:ScheduleEvent("OrmanosTestChargeOther", self.Emote, 10, self,
+		"Ormanos is preparing to charge "..other.."!")
+	self:ScheduleEvent("OrmanosTestLandOther", self.LandEvent, 14, self,
+		"Ormanos the Cracked 's Rampaging Earth hits "..other.." for 2500 Nature damage.")
+
+	self:ScheduleEvent("OrmanosTestEnd", self.OnDisengage, 16, self)
+	return true
+end

--- a/Raids/TMH/Partath.lua
+++ b/Raids/TMH/Partath.lua
@@ -1,0 +1,187 @@
+
+local module, L = BigWigs:ModuleDeclaration("Chieftain Partath", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = module.translatedName
+module.toggleoptions = {"might", "immune", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Partath",
+
+	might_cmd = "might",
+	might_name = "Might of the Chieftain Bar",
+	might_desc = "Tracks Chieftain Partath's Might of the Chieftain stacks (caps at 50)",
+
+	immune_cmd = "immune",
+	immune_name = "Immune (Shade of the Withermaw) Timer",
+	immune_desc = "Shows a 15 second bar when Chieftain Partath gains Shade of the Withermaw",
+
+	trigger_mightStack = "Chieftain Partath gains Might of the Chieftain %((%d+)%)",
+	trigger_immuneGain = "Chieftain Partath gains Shade of the Withermaw",
+	trigger_immuneFade = "Shade of the Withermaw fades from Chieftain Partath",
+
+	bar_might = "Might of the Chieftain",
+	bar_immune = "Immune",
+	bar_nextImmune = "Next Immune",
+
+	msg_immune = "Chieftain Partath is immune - bring Illuminators to him!",
+	msg_immuneOver = "Immune ended!",
+} end )
+
+local candybar = AceLibrary("CandyBar-2.2")
+
+local timer = {
+	mightCap = 50,
+	immune = 15,
+	immuneCycle = 52,
+}
+
+local icon = {
+	might = "Ability_Druid_Maul",
+	immune = "Spell_Shadow_SummonVoidWalker",
+	immuneCycle = "spell_cloaked_in_shadows_2",
+}
+
+local syncName = {
+	mightStack = "PartathMight"..module.revision,
+	immuneGain = "PartathImmune"..module.revision,
+	immuneFade = "PartathImmuneOff"..module.revision,
+}
+
+function module:OnEnable()
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Event")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "Event")
+
+	self:ThrottleSync(0, syncName.mightStack)
+	self:ThrottleSync(5, syncName.immuneGain)
+	self:ThrottleSync(5, syncName.immuneFade)
+end
+
+function module:OnSetup()
+	self.mightStacks = 0
+end
+
+function module:OnEngage()
+	self.mightStacks = 0
+	if self.db.profile.immune then
+		self:StartNextImmuneBar()
+		self:ScheduleRepeatingEvent("PartathNextImmune", self.StartNextImmuneBar, timer.immuneCycle, self)
+	end
+end
+
+function module:StartNextImmuneBar()
+	self:RemoveBar(L["bar_nextImmune"])
+	self:Bar(L["bar_nextImmune"], timer.immuneCycle, icon.immuneCycle, true, "Blue")
+end
+
+function module:OnDisengage()
+	self:TriggerEvent("BigWigs_StopCounterBar", self, L["bar_might"])
+	self:RemoveBar(L["bar_immune"])
+	if self:IsEventScheduled("PartathNextImmune") then
+		self:CancelScheduledEvent("PartathNextImmune")
+	end
+	self:RemoveBar(L["bar_nextImmune"])
+end
+
+function module:Event(msg)
+	local _, _, stacks = string.find(msg, L["trigger_mightStack"])
+	if stacks then
+		self:Sync(syncName.mightStack.." "..stacks)
+		return
+	end
+	if string.find(msg, L["trigger_immuneGain"]) then
+		self:Sync(syncName.immuneGain)
+	elseif string.find(msg, L["trigger_immuneFade"]) then
+		self:Sync(syncName.immuneFade)
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.mightStack and rest and self.db.profile.might then
+		local n = tonumber(rest)
+		if n then self:UpdateMight(n) end
+	elseif sync == syncName.immuneGain and self.db.profile.immune then
+		self:ImmuneStart()
+	elseif sync == syncName.immuneFade and self.db.profile.immune then
+		self:ImmuneEnd()
+	end
+end
+
+function module:StartMightBar(stacks)
+	self:TriggerEvent("BigWigs_StartCounterBar", self, L["bar_might"], timer.mightCap, "Interface\\Icons\\"..icon.might, true, "White")
+	self:TriggerEvent("BigWigs_SetCounterBar", self, L["bar_might"], timer.mightCap - stacks)
+	self:ApplyMightTextColor(stacks)
+end
+
+function module:UpdateMight(stacks)
+	if stacks <= self.mightStacks then return end
+	local prev = self.mightStacks
+	self.mightStacks = stacks
+	if stacks > timer.mightCap then stacks = timer.mightCap end
+
+	if prev == 0 then
+		self:TriggerEvent("BigWigs_StartCounterBar", self, L["bar_might"], timer.mightCap, "Interface\\Icons\\"..icon.might, true, "White")
+	end
+	self:TriggerEvent("BigWigs_SetCounterBar", self, L["bar_might"], timer.mightCap - stacks)
+	self:ApplyMightTextColor(stacks)
+end
+
+function module:ApplyMightTextColor(stacks)
+	local id = "BigWigsBar "..L["bar_might"]
+	local c = "White"
+	if stacks >= 40 then
+		c = "Red"
+	elseif stacks >= 30 then
+		c = "Yellow"
+	end
+	candybar:SetColor(id, c, 1)
+end
+
+function module:ImmuneStart()
+	self:RemoveBar(L["bar_immune"])
+	self:Bar(L["bar_immune"], timer.immune, icon.immune, true, "Black")
+	self:Message(L["msg_immune"], "Urgent", false, "Alarm")
+end
+
+function module:ImmuneEnd()
+	self:RemoveBar(L["bar_immune"])
+	self:Message(L["msg_immuneOver"], "Positive")
+end
+
+-- Spoofs real combat-log strings through Event() so the full parse -> sync
+-- -> handler chain is exercised. Requires the player to be in a raid for
+-- Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Chieftain Partath"); BigWigs:SetupModule("Chieftain Partath"); m:Test();
+function module:Test()
+	timer.immuneCycle = 12
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+	self:Message("Chieftain Partath test started", "Positive")
+
+	local stackEvents = {
+		{t = 2,  s = 2},
+		{t = 4,  s = 5},
+		{t = 6,  s = 9},
+		{t = 8,  s = 15},
+		{t = 10, s = 22},
+		{t = 12, s = 30},
+		{t = 14, s = 38},
+		{t = 16, s = 42},
+		{t = 18, s = 50},
+	}
+	for i, e in ipairs(stackEvents) do
+		local t, s = e.t, e.s
+		local msg = "Chieftain Partath gains Might of the Chieftain ("..s..")."
+		self:ScheduleEvent("PartathTestStack"..i, self.Event, t, self, msg)
+	end
+
+	self:ScheduleEvent("PartathTestImmuneOn",  self.Event, 20, self,
+		"Chieftain Partath gains Shade of the Withermaw (1).")
+	self:ScheduleEvent("PartathTestImmuneOff", self.Event, 27, self,
+		"Shade of the Withermaw fades from Chieftain Partath.")
+	self:ScheduleEvent("PartathTestRestore", function() timer.immuneCycle = 52 end, 32)
+	self:ScheduleEvent("PartathTestEnd", self.OnDisengage, 32, self)
+	return true
+end

--- a/Raids/TMH/Rotgrowl.lua
+++ b/Raids/TMH/Rotgrowl.lua
@@ -1,0 +1,124 @@
+
+local module, L = BigWigs:ModuleDeclaration("Rotgrowl", "Timbermaw Hold")
+
+module.revision = 30000
+module.enabletrigger = module.translatedName
+module.toggleoptions = {"flamingbolt", "bosskill"}
+module.zonename = "Timbermaw Hold"
+
+L:RegisterTranslations("enUS", function() return {
+	cmd = "Rotgrowl",
+
+	flamingbolt_cmd = "flamingbolt",
+	flamingbolt_name = "Flaming Bolt Alert",
+	flamingbolt_desc = "Warns when Rotgrowl aims a flaming bolt at a player (Fire-Soaked Arrow)",
+
+	trigger_flamingBolt = "aims a flaming bolt at (.+)!",
+	trigger_boltLand = "Fire%-Soaked Arrow hits",
+
+	msg_boltYou = "FLAMING BOLT ON YOU - STACK IN MELEE!",
+} end )
+
+local icon = {
+	flamingBolt = "Spell_Fire_Fireball02",
+}
+
+local syncName = {
+	flamingBolt = "RotgrowlFlamingBolt"..module.revision,
+	boltLand    = "RotgrowlFlamingBoltLand"..module.revision,
+}
+
+function module:OnEnable()
+	self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE", "Emote")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "LandEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "LandEvent")
+	self:ThrottleSync(3, syncName.flamingBolt)
+	self:ThrottleSync(1, syncName.boltLand) -- per-target dedup via markedTarget
+end
+
+function module:OnSetup()
+	self.markedTarget = nil
+end
+function module:OnEngage() end
+function module:OnDisengage()
+	-- Framework auto-restores initialPlayerMarks on disengage (Core.lua:484-488)
+	self.markedTarget = nil
+end
+
+function module:Emote(msg)
+	local _, _, target = string.find(msg, L["trigger_flamingBolt"])
+	if target then
+		self:Sync(syncName.flamingBolt.." "..target)
+	end
+end
+
+function module:LandEvent(msg)
+	if self.markedTarget and string.find(msg, L["trigger_boltLand"]) then
+		-- broadcast so the raid leader (possibly not the seer of this msg)
+		-- is the one that actually calls SetRaidTarget to restore
+		self:Sync(syncName.boltLand.." "..self.markedTarget)
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.flamingBolt and rest and self.db.profile.flamingbolt then
+		self:FlamingBolt(rest)
+	elseif sync == syncName.boltLand and rest then
+		if self.markedTarget == rest then
+			self:RestorePreviousRaidTargetForPlayer(rest)
+			self.markedTarget = nil
+		end
+	end
+end
+
+function module:FlamingBolt(target)
+	if target == UnitName("player") then
+		self:Message(L["msg_boltYou"], "Personal", true, "Alarm")
+		self:WarningSign(icon.flamingBolt, 3, true)
+	end
+
+	if self.markedTarget and self.markedTarget ~= target then
+		self:RestorePreviousRaidTargetForPlayer(self.markedTarget)
+	end
+	self.markedTarget = target
+	self:SetRaidTargetForPlayer(target, 8) -- Skull
+end
+
+-- Spoofs real combat-log strings through Emote() and LandEvent() so the full
+-- parse -> sync -> handler chain is exercised. Requires the player to be in a
+-- raid for Sync's local echo to reach BigWigs_RecvSync.
+-- Usage: /run local m=BigWigs:GetModule("Rotgrowl"); BigWigs:SetupModule("Rotgrowl"); m:Test();
+function module:Test()
+	self:OnSetup()
+	self:OnEnable()
+	self:SendEngageSync()
+	self:Message("Rotgrowl test started", "Positive")
+
+	local player = UnitName("player")
+
+	-- pick a second target from the raid (any raid member other than player)
+	local other
+	for i = 1, GetNumRaidMembers() do
+		local name = UnitName("raid"..i)
+		if name and name ~= player then
+			other = name
+			break
+		end
+	end
+	if not other then other = player end -- solo fallback: both bolts on player
+
+	-- first bolt: on you
+	self:ScheduleEvent("RotgrowlTestBoltYou", self.Emote, 2, self,
+		"Rotgrowl aims a flaming bolt at "..player.."!")
+	self:ScheduleEvent("RotgrowlTestLandYou", self.LandEvent, 8, self,
+		"Rotgrowl 's Fire-Soaked Arrow hits "..player.." for 857 Fire damage.")
+
+	-- second bolt: on another raid member
+	self:ScheduleEvent("RotgrowlTestBoltOther", self.Emote, 12, self,
+		"Rotgrowl aims a flaming bolt at "..other.."!")
+	self:ScheduleEvent("RotgrowlTestLandOther", self.LandEvent, 18, self,
+		"Rotgrowl 's Fire-Soaked Arrow hits "..other.." for 857 Fire damage.")
+
+	self:ScheduleEvent("RotgrowlTestEnd", self.OnDisengage, 20, self)
+	return true
+end


### PR DESCRIPTION
- Karrsh: Furious Roar bar gated to Spear phase, Seed of Corruption rotating marks
- Rotgrowl: flaming bolt personal warning, skull mark, restored on arrow land (synced)
- Ormanos: preparing-to-charge warning, skull mark, restored on Rampaging Earth (synced)
- Loktanag: Infected Secretion 12-14s interval bar, starts on first cast
- Partath: Might of the Chieftain stack counter, Shade of the Withermaw immune, 52s next-immune cycle
- Kronn: dual HP frame synced via UNIT_HEALTH, Dream Fever rotating marks, victory on friendliness
- Core: register Timbermaw Hold zone, add to raidZones list
- Babble-Boss: register TMH boss/add names (enUS), bump 20007 -> 20008
- Custom-frame backdrops (Thaddius / Horsemen / Gnarlmoon / Anomalus) tightened insets 8 -> 4