### PR TITLE
(TMH) hide Kronn HP frame on disengage

### DIFF
--- a/Raids/TMH/Kronn.lua
+++ b/Raids/TMH/Kronn.lua
@@ -108,6 +108,9 @@ end
 function module:OnDisengage()
 	-- Framework auto-restores initialPlayerMarks on disengage (Core.lua:484-488)
 	self.feverTargets = {}
+	if self.hpFrame then
+		self.hpFrame:Hide()
+	end
 end
 
 function module:AfflictionEvent(msg)


### PR DESCRIPTION
Kronn's HP frame stayed on screen after victory/wipe/reboot. Matches the Thaddius/Horsemen/Gnarlmoon idiom of Hide()ing the custom frame in OnDisengage.