### PR TITLE
fix Kel'Thuzad fight not ending on death

### DIFF
--- a/Raids/Naxxramas/Kelthuzad.lua
+++ b/Raids/Naxxramas/Kelthuzad.lua
@@ -666,6 +666,9 @@ end
 function module:Victory()
 	-- reset farclip back to saved value
 	SetCVar("farclip", BigWigsFarclip.db.profile.defaultFarclip)
+	-- fall through to the base prototype so the module actually disables
+	-- (Core.lua Victory fires bosskill msg, ends BossRecords, DisableModule)
+	BigWigs.modulePrototype.Victory(self)
 end
 
 function module:MINIMAP_ZONE_CHANGED(msg)


### PR DESCRIPTION
The Kel'Thuzad module's `Victory()` override only reset the farclip CVar and skipped the base prototype's `DisableModule` chain, so the module stayed engaged after the kill. Bars persisted, BossRecords never closed, and `OnDisengage` cleanup never ran.

Now falls through to `BigWigs.modulePrototype.Victory(self)` after the farclip reset so the full kill flow runs.