### PR TITLE
(TMH) Peroth'arn: check IsEventRegistered before unregistering

### DIFF
--- a/Raids/TMH/Perotharn.lua
+++ b/Raids/TMH/Perotharn.lua
@@ -77,7 +77,9 @@ end
 
 function module:UnregisterAbsorbEvents()
 	for _, event in ipairs(absorbEvents) do
-		self:UnregisterEvent(event)
+		if self:IsEventRegistered(event) then
+			self:UnregisterEvent(event)
+		end
 	end
 end
 


### PR DESCRIPTION
## Summary
- Guard `UnregisterEvent` calls with `IsEventRegistered` so ending the fight without the shield ever going up doesn't spam unregister warnings